### PR TITLE
Fix file write mode in uploadFile function

### DIFF
--- a/files.go
+++ b/files.go
@@ -1173,7 +1173,7 @@ func uploadFile(ctx context.Context, file *File, encryptionKey string, contents 
 		} else if file.StorageArea == "s3" {
 			log.Printf("SHOULD UPLOAD TO S3!")
 		} else {
-			f, err := os.OpenFile(file.DownloadPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, os.ModePerm)
+			f, err := os.OpenFile(file.DownloadPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.ModePerm)
 
 			if err != nil {
 				// Rolling back file


### PR DESCRIPTION
Previously this function used append mode to open the file being updated which caused issue of duplication of data in the file. This commit changes the mode to open file to write mode as well as enable truncation of the file.

Fixes https://github.com/Shuffle/Shuffle/issues/1176

I tested it locally, please take a look at the video where the above issue doesn't happen.

https://github.com/Shuffle/shuffle-shared/assets/49693820/6dce185f-ab4c-4f13-9865-7c90aede7ef3
