### PR TITLE
feat : added backend logic for getting all the triggers

### DIFF
--- a/db-connector.go
+++ b/db-connector.go
@@ -7669,6 +7669,185 @@ func GetSchedule(ctx context.Context, schedulename string) (*ScheduleOld, error)
 	return curUser, nil
 }
 
+func GetHooks(ctx context.Context, OrgId string) ([]Hook, error) {
+	hooks := []Hook{}
+	nameKey := "hooks"
+	OrgId = strings.ToLower(OrgId)
+
+	//FIXME: Implement caching
+
+	if project.DbType == "opensearch" {
+		var buf bytes.Buffer
+		query := map[string]interface{}{
+			"from": 0,
+			"size": 1000,
+			"query": map[string]interface{}{
+				"match": map[string]interface{}{
+					"org_id": OrgId,
+				},
+			},
+		}
+
+		if err := json.NewEncoder(&buf).Encode(query); err != nil {
+			log.Printf("[WARNING] Error encoding find user query: %s", err)
+			return []Hook{}, err
+		}
+
+		res, err := project.Es.Search(
+			project.Es.Search.WithContext(ctx),
+			project.Es.Search.WithIndex(strings.ToLower(GetESIndexPrefix(nameKey))),
+			project.Es.Search.WithBody(&buf),
+			project.Es.Search.WithTrackTotalHits(true),
+		)
+		if err != nil {
+			log.Printf("[ERROR] Error getting response from Opensearch (get hooks): %s", err)
+			return []Hook{}, err
+		}
+
+		defer res.Body.Close()
+		if res.StatusCode == 404 {
+			return []Hook{}, nil
+		}
+
+		defer res.Body.Close()
+		if res.IsError() {
+			var e map[string]interface{}
+			if err := json.NewDecoder(res.Body).Decode(&e); err != nil {
+				log.Printf("[WARNING] Error parsing the response body: %s", err)
+				return []Hook{}, nil
+			} else {
+				// Print the response status and error information.
+				log.Printf("[%s] %s: %s",
+					res.Status(),
+					e["error"].(map[string]interface{})["type"],
+					e["error"].(map[string]interface{})["reason"],
+				)
+			}
+		}
+
+		if res.StatusCode != 200 && res.StatusCode != 201 {
+			return []Hook{}, fmt.Errorf("Bad statuscode: %d", res.StatusCode)
+		}
+
+		respBody, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return []Hook{}, err
+		}
+		wrapper := AllHooksWrapper{}
+		err = json.Unmarshal(respBody, &wrapper)
+	
+		if err != nil {
+			return []Hook{}, err
+		}
+
+		for _, hit := range wrapper.Hits.Hits {
+			hook := hit.Source 
+			hooks = append(hooks, hook) 
+		}
+		return hooks, err
+		
+	} else {
+		q := datastore.NewQuery(nameKey).Filter("org_id = ", OrgId).Limit(1000)
+
+		_, err := project.Dbclient.GetAll(ctx, q, &hooks)
+		if err != nil && len(hooks) == 0 {
+			return hooks, err
+		}
+	}
+
+	return hooks, nil
+}
+
+func GetPipelines(ctx context.Context, OrgId string) ([]Pipeline, error) {
+	pipelines := []Pipeline{}
+	nameKey := "pipelines"
+	OrgId = strings.ToLower(OrgId)
+
+	//FIXME: Implement caching
+
+	if project.DbType == "opensearch" {
+		var buf bytes.Buffer
+		query := map[string]interface{}{
+			"from": 0,
+			"size": 1000,
+			"query": map[string]interface{}{
+				"match": map[string]interface{}{
+					"org_id": OrgId,
+				},
+			},
+		}
+
+		if err := json.NewEncoder(&buf).Encode(query); err != nil {
+			log.Printf("[WARNING] Error encoding find user query: %s", err)
+			return []Pipeline{}, err
+		}
+
+		res, err := project.Es.Search(
+			project.Es.Search.WithContext(ctx),
+			project.Es.Search.WithIndex(strings.ToLower(GetESIndexPrefix(nameKey))),
+			project.Es.Search.WithBody(&buf),
+			project.Es.Search.WithTrackTotalHits(true),
+		)
+		if err != nil {
+			log.Printf("[ERROR] Error getting response from Opensearch (get pipelines): %s", err)
+			return []Pipeline{}, err
+		}
+
+		defer res.Body.Close()
+		if res.StatusCode == 404 {
+			return []Pipeline{}, nil
+		}
+
+		defer res.Body.Close()
+		if res.IsError() {
+			var e map[string]interface{}
+			if err := json.NewDecoder(res.Body).Decode(&e); err != nil {
+				log.Printf("[WARNING] Error parsing the response body: %s", err)
+				return []Pipeline{}, nil
+			} else {
+				// Print the response status and error information.
+				log.Printf("[%s] %s: %s",
+					res.Status(),
+					e["error"].(map[string]interface{})["type"],
+					e["error"].(map[string]interface{})["reason"],
+				)
+			}
+		}
+
+		if res.StatusCode != 200 && res.StatusCode != 201 {
+			return []Pipeline{}, fmt.Errorf("bad statuscode: %d", res.StatusCode)
+			
+		}
+
+		respBody, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return []Pipeline{}, err
+		}
+		wrapper := AllPipelinesWrapper{}
+		err = json.Unmarshal(respBody, &wrapper)
+	
+		if err != nil {
+			return []Pipeline{}, err
+		}
+
+		for _, hit := range wrapper.Hits.Hits {
+			pipeline := hit.Source 
+			pipelines = append(pipelines, pipeline) 
+		}
+		return pipelines, err
+		
+	} else {
+		// q := datastore.NewQuery(nameKey).Filter("org_id = ", OrgId).Limit(1000)
+
+		// _, err := project.Dbclient.GetAll(ctx, q, &pipelines)
+		// if err != nil && len(pipelines) == 0 {
+		// 	return pipelines, err
+		// }
+	}
+
+	return pipelines, nil
+}
+
 func GetSessionNew(ctx context.Context, sessionId string) (User, error) {
 	cacheKey := fmt.Sprintf("session_%s", sessionId)
 	user := &User{}

--- a/shared.go
+++ b/shared.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 
@@ -3867,6 +3868,262 @@ func SetAuthenticationConfig(resp http.ResponseWriter, request *http.Request) {
 	//var config configAuth
 
 	//log.Printf("Should set %s
+}
+
+func HandleGetTriggers(resp http.ResponseWriter, request *http.Request) {
+
+	cors := HandleCors(resp, request)
+	if cors {
+		return
+	}
+
+	user, err := HandleApiAuthentication(resp, request)
+	if err != nil {
+		log.Printf("[WARNING] Api authentication failed in get schedules: %s", err)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success":false}`))
+		return
+	}
+
+	ctx := GetContext(request)
+	workflowsChan := make(chan []Workflow)
+	schedulesChan := make(chan []ScheduleOld)
+	hooksChan := make(chan []Hook)
+	//pipelinesChan := make(chan []Pipeline)
+	errChan := make(chan error)
+
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+
+	go func() {
+		workflows, err := GetAllWorkflowsByQuery(ctx, user)
+		if err != nil {
+			wg.Done()
+			errChan <- err
+			return
+		}
+		wg.Done()
+		workflowsChan <- workflows
+
+	}()
+
+	go func() {
+		schedules, err := GetAllSchedules(ctx, user.ActiveOrg.Id)
+		if err != nil {
+			wg.Done()
+			errChan <- err
+			return
+		}
+		wg.Done()
+		schedulesChan <- schedules
+
+	}()
+
+	go func() {
+		hooks, err := GetHooks(ctx, user.ActiveOrg.Id)
+		if err != nil {
+			wg.Done()
+			errChan <- err
+			return
+		}
+		wg.Done()
+		hooksChan <- hooks
+	}()
+
+	// go func() {
+	// 	pipelines, err := GetPipelines(ctx, user.ActiveOrg.Id)
+	// 	if err != nil {
+	// 		wg.Done()
+	// 		errChan <- err
+	// 		return
+	// 	}
+	// 	wg.Done()
+	// 	pipeliesChan <- pipelines
+	// }()
+
+	wg.Wait()
+
+	log.Println("[INFO] All Go routines Completed")
+	// this is to check if we got any errors without blocking the entire process
+	select {
+	case err := <-errChan:
+		if err != nil {
+			log.Printf("[ERROR] Failed to fetch data: %s", err)
+			resp.WriteHeader(500)
+			resp.Write([]byte(`{"success":false}`))
+			return
+		}
+	default:
+		log.Println("[INFO] No errors received within Go routines, proceeding with further logic")
+	}
+
+	hooks := <-hooksChan
+	schedules := <-schedulesChan
+	workflows := <-workflowsChan
+	//pipelines := <- pipeliesChan
+
+	log.Printf("[INFO] recieved all the data from the channels")
+
+	hookMap := map[string]Hook{}
+	scheduleMap := map[string]ScheduleOld{}
+
+	for _, hook := range hooks {
+		hookMap[hook.Id] = hook
+	}
+	for _, schedule := range schedules {
+		scheduleMap[schedule.Id] = schedule
+	}
+
+	allHooks := []Hook{}
+	allSchedules := []ScheduleOld{}
+	// Now loop through the workflow triggers to see if anything is not in sync
+	for _, workflow := range workflows {
+		for _, trigger := range workflow.Triggers {
+
+			if trigger.Status == "uninitialized" {
+				continue
+			}
+
+			switch trigger.TriggerType {
+			case "WEBHOOK":
+				{
+					hook := Hook{}
+					storedHook, exist := hookMap[trigger.ID]
+					if !exist {
+
+						auth := ""
+						version := ""
+						customBody := ""
+						startNode := ""
+
+						hook.Id = trigger.ID
+						hook.Environment = trigger.Environment
+						hook.Workflows = []string{workflow.ID}
+						hook.Owner = workflow.Owner
+						hook.OrgId = workflow.OrgId
+
+						hookInfo := Info{}
+						for _, param := range trigger.Parameters {
+							if param.Name == "url" {
+								hookInfo.Url = param.Value
+								hookInfo.Name = trigger.Label
+							} else if param.Name == "auth_headers" {
+								auth = param.Value
+							} else if param.Name == "await_response" {
+								version = param.Value
+							} else if param.Name == "custom_response_body" {
+								customBody = param.Value
+							}
+						}
+						hook.Info = hookInfo
+
+						// searching for start node
+						if len(workflow.Branches) != 0 {
+							for _, branch := range workflow.Branches {
+								if branch.SourceID == trigger.ID {
+									startNode = branch.DestinationID
+								}
+							}
+						}
+						if startNode == "" {
+							startNode = workflow.Start
+						}
+						hook.Start = startNode
+						hook.Status = "stopped"
+						hook.Running = false
+						
+						hook.Auth = auth
+						hook.Version = version
+						hook.CustomResponse = customBody
+						allHooks = append(allHooks, hook)
+					} else {
+						hookValue := storedHook
+						hookValue.Status = "running"
+						for _, param := range trigger.Parameters {
+							if param.Name == "url" {
+								hookValue.Info.Url = param.Value
+								hookValue.Info.Name = trigger.Label
+							}
+						}
+						
+						allHooks = append(allHooks, hookValue)
+					}
+				}
+			case "SCHEDULE":
+				{
+					schedule := ScheduleOld{}
+					storedschedule, exist := scheduleMap[trigger.ID]
+					if !exist {
+
+						startNode := ""
+
+						schedule.Id = trigger.ID
+						schedule.WorkflowId = workflow.ID
+						schedule.Environment = trigger.Environment
+						schedule.Org = workflow.OrgId
+						schedule.Name = trigger.Label
+
+						for _, param := range trigger.Parameters {
+							if param.Name == "cron" {
+								schedule.Frequency = param.Value
+							} else if param.Name == "execution_argument" {
+								schedule.Argument = param.Value
+							}
+						}
+
+						for _, branch := range workflow.Branches {
+							if branch.SourceID == schedule.Id {
+								startNode = branch.DestinationID
+							}
+						}
+
+						if startNode == "" {
+							startNode = workflow.Start
+						}
+						schedule.StartNode = startNode
+						Wrapper := fmt.Sprintf(`{"start": "%s", "execution_source": "schedule", "execution_argument": "%s"}`, startNode, schedule.Argument)
+						schedule.WrappedArgument = Wrapper
+						schedule.Status = "stopped"
+	
+						allSchedules = append(allSchedules, schedule)
+					} else {
+						scheduleValue := storedschedule
+						scheduleValue.Name = trigger.Label
+						scheduleValue.Status = "running"
+
+						allSchedules = append(allSchedules, scheduleValue)
+					}
+				}
+			}
+		}
+	}
+
+	sort.SliceStable(allHooks, func(i, j int) bool {
+        return allHooks[i].Info.Name < allHooks[j].Info.Name
+    })
+	sort.SliceStable(allSchedules, func(i, j int) bool {
+        return allSchedules[i].Name < allSchedules[j].Name
+    })
+	// sort.SliceStable(pipelines, func(i, j int) bool {
+    //     return pipelines[i].Name < pipelines[j].Name
+    // })
+
+	allTriggersWrapper := AllTriggersWrapper{}
+
+	allTriggersWrapper.WebHooks = allHooks
+	allTriggersWrapper.Schedules = allSchedules
+	// allTriggersWrapper.Pipelines = pipelines
+
+	newjson, err := json.Marshal(allTriggersWrapper)
+	if err != nil {
+		log.Printf("Failed unmarshal: %s", err)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false, "reason": "Failed unpacking environments"}`))
+		return
+	}
+
+	resp.WriteHeader(200)
+	resp.Write(newjson)
 }
 
 func HandleGetSchedules(resp http.ResponseWriter, request *http.Request) {

--- a/structs.go
+++ b/structs.go
@@ -33,7 +33,7 @@ type Pipeline struct {
 	StartNode   string 		`json:"start_node"`
 	OrgId       string 		`json:"org_id"`
 	Status      string 		`json:"status"`
-	Errors      []string 	`json:"errors"`
+	Error       string 	    `json:"error"`
 	
 	PipelineId 	string 		`json:"pipeline_id"`
 	TriggerId	string 		`json:"trigger_id"`

--- a/structs.go
+++ b/structs.go
@@ -24,6 +24,36 @@ type PipelineRequest struct {
 	TriggerId  string `json:"trigger_id"`
 }
 
+type Pipeline struct {
+	Name	   	string 		`json:"name"`
+	Type 		string 		`json:"type"`
+	Command		string 		`json:"command"`
+	Environment string 		`json:"environment"`
+	WorkflowId  string 		`json:"workflow_id"`
+	StartNode   string 		`json:"start_node"`
+	OrgId       string 		`json:"org_id"`
+	Status      string 		`json:"status"`
+	Errors      []string 	`json:"errors"`
+	
+	PipelineId 	string 		`json:"pipeline_id"`
+	TriggerId	string 		`json:"trigger_id"`
+}
+
+type AllPipelinesWrapper struct {
+	Hits struct {
+		Total struct {
+			Value    int    `json:"value"`
+			Relation string `json:"relation"`
+		} `json:"total"`
+		Hits     []struct {
+			Index  string  `json:"_index"`
+			ID     string  `json:"_id"`
+			Score  float64 `json:"_score"`
+			Source Pipeline `json:"_source"`
+		} `json:"hits"`
+	} `json:"hits"`
+}
+
 type QueryInput struct {
 	// Required
 	Query string `json:"query"`
@@ -601,6 +631,7 @@ type AppInfo struct {
 }
 
 type ScheduleOld struct {
+	Name                 string       `json:"name" datastore:"name"`
 	Id                   string       `json:"id" datastore:"id"`
 	StartNode            string       `json:"start_node" datastore:"start_node"`
 	Seconds              int          `json:"seconds" datastore:"seconds"`
@@ -619,6 +650,7 @@ type ScheduleOld struct {
 	LastRuntime          int64        `json:"lastruntime" datastore:"lastruntime,noindex"`
 	Frequency            string       `json:"frequency" datastore:"frequency,noindex"`
 	Environment          string       `json:"environment" datastore:"environment"`
+	Status               string       `json:"status" datastore:"status"`
 }
 
 // Returned from /GET /schedules
@@ -2102,6 +2134,12 @@ type SubResponse struct {
 	Expiration string `json:"expiration`
 }
 
+type AllTriggersWrapper struct {
+	// Pipelines []Pipeline `json:"pipelines"`
+	WebHooks   []Hook `json:"webhooks"`
+	Schedules []ScheduleOld `json:"schedules"`
+}
+
 type SubWrapper struct {
 	Index       string                `json:"_index"`
 	Type        string                `json:"_type"`
@@ -2243,6 +2281,21 @@ type HookWrapper struct {
 	PrimaryTerm int    `json:"_primary_term"`
 	Found       bool   `json:"found"`
 	Source      Hook   `json:"_source"`
+}
+
+type AllHooksWrapper struct {
+	Hits struct {
+		Total struct {
+			Value    int    `json:"value"`
+			Relation string `json:"relation"`
+		} `json:"total"`
+		Hits     []struct {
+			Index  string  `json:"_index"`
+			ID     string  `json:"_id"`
+			Score  float64 `json:"_score"`
+			Source Hook `json:"_source"`
+		} `json:"hits"`
+	} `json:"hits"`
 }
 
 type ScheduleWrapper struct {


### PR DESCRIPTION
`HandleGetTriggers` will return all the various triggers like webhooks , schedules , pipelines etc.. 
- first it will query for all the triggers from the db and then stores in the map for faster lookups 
- it compares with the trigger found in the workflow and the one stored in the map using the `TriggerId` if it exists that means it is still running if not then the status of the trigger is stopped
- finally it will wrap all the triggers