### PR TITLE
modified pipelines.go to make the pipelines work 

### DIFF
--- a/db-connector.go
+++ b/db-connector.go
@@ -7889,6 +7889,31 @@ func GetApikey(ctx context.Context, apikey string) (User, error) {
 	return users[0], nil
 }
 
+func savePipelineData(ctx context.Context, pipeline Pipeline) error {
+	// assuming IndexRequest can be used as an upsert operation
+	nameKey := "pipelines"
+
+	pipelineData, err := json.Marshal(pipeline)
+	if err != nil {
+		log.Printf("[WARNING] Failed marshalling in savePipelineData: %s", err)
+		return err
+	}
+	triggerId := strings.ToLower(pipeline.TriggerId)
+	if project.DbType == "opensearch" {
+		err = indexEs(ctx, nameKey, triggerId, pipelineData)
+		if err != nil {
+			return err
+		}
+	} else {
+		// key := datastore.NameKey(nameKey, pipelineId, nil)
+		// if _, err := project.Dbclient.Put(ctx, key, &pipeline); err != nil {
+		// 	log.Printf("[ERROR] failed to add pipeline: %s", err)
+		// 	return err
+	}
+
+	return nil
+}
+
 func GetHook(ctx context.Context, hookId string) (*Hook, error) {
 	nameKey := "hooks"
 	hookId = strings.ToLower(hookId)
@@ -7997,6 +8022,46 @@ func SetHook(ctx context.Context, hook Hook) error {
 	}
 
 	return nil
+}
+
+func GetPipeline(ctx context.Context, triggerId string) (*Pipeline, error) {
+	pipeline := &Pipeline{}
+	nameKey := "pipelines"
+	
+	triggerId = strings.ToLower(triggerId)
+
+	if project.DbType == "opensearch" {
+
+		res, err := project.Es.Get(strings.ToLower(GetESIndexPrefix(nameKey)), triggerId)
+		if err != nil {
+			return &Pipeline{}, err
+		}
+
+		defer res.Body.Close()
+		if res.StatusCode == 404 {
+			return &Pipeline{}, errors.New("pipeline doesn't exist")
+		}
+
+		respBody, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return &Pipeline{}, err
+		}
+
+		wrapped := PipelineWrapper{}
+		err = json.Unmarshal(respBody, &wrapped)
+		if err != nil {
+			return &Pipeline{}, err
+		}
+
+		pipeline = &wrapped.Source
+	}  else {
+		// key := datastore.NameKey(nameKey, triggerId, nil)
+		// err := project.Dbclient.Get(ctx, key, pipeline)
+		// if err != nil {
+		// 	return &Pipeline{}, err
+		// }
+	}
+	return pipeline, nil
 }
 
 func GetNotification(ctx context.Context, id string) (*Notification, error) {

--- a/pipelines.go
+++ b/pipelines.go
@@ -1,14 +1,14 @@
 package shuffle
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
-	"io/ioutil"
-	"encoding/json"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // Pipeline is a sequence of stages that are executed in order.
@@ -75,7 +75,6 @@ func HandleNewPipelineRegister(resp http.ResponseWriter, request *http.Request) 
 		return
 	}
 
-
 	ctx := GetContext(request)
 	environments, err := GetEnvironments(ctx, user.ActiveOrg.Id)
 	if err != nil {
@@ -101,7 +100,7 @@ func HandleNewPipelineRegister(resp http.ResponseWriter, request *http.Request) 
 	}
 
 	availableCommands := []string{
-		"create",
+		"create", "delete", "start", "stop",
 	}
 
 	matchingCommand := ""
@@ -120,13 +119,12 @@ func HandleNewPipelineRegister(resp http.ResponseWriter, request *http.Request) 
 	}
 
 	// 1. Add to trigger list
-	/* TBD */ 
-
+	/* TBD */
 
 	// Look for PIPELINE_ command that exists in the queue already
-	parsedId := fmt.Sprintf("%s_%s", strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(pipeline.Environment, " ", "-"), "_", "-")), user.ActiveOrg.Id)
-
 	startCommand := strings.ToUpper(strings.Split(pipeline.Type, " ")[0])
+	//parsedId := fmt.Sprintf("%s_%s", strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(pipeline.Environment, " ", "-"), "_", "-")), user.ActiveOrg.Id)
+	parsedId := strings.ToLower(pipeline.Environment)
 	formattedType := fmt.Sprintf("PIPELINE_%s", startCommand)
 	existingQueue, err := GetWorkflowQueue(ctx, parsedId, 10)
 	for _, queue := range existingQueue.Data {
@@ -142,11 +140,33 @@ func HandleNewPipelineRegister(resp http.ResponseWriter, request *http.Request) 
 
 	// 2. Send to environment queue
 	execRequest := ExecutionRequest{
-		Type: formattedType,
-		ExecutionId: uuid.NewV4().String(),
-		ExecutionSource: pipeline.Name,
+		Type:              formattedType,
+		ExecutionId:       uuid.NewV4().String(),
+		ExecutionSource:   pipeline.TriggerId,
 		ExecutionArgument: pipeline.Command,
-		Priority: 11,
+		Priority:          11,
+	}
+
+	if startCommand == "CREATE" {
+
+		pipelineData := Pipeline{}
+		pipelineData.Name = pipeline.Name
+		pipelineData.Type = startCommand
+		pipelineData.Command = pipeline.Command
+		pipelineData.Environment = pipeline.Environment
+		pipelineData.WorkflowId = pipeline.WorkflowId
+		pipelineData.OrgId = user.ActiveOrg.Id
+		pipelineData.Status = "uninitialized"
+		pipelineData.TriggerId = pipeline.TriggerId
+
+		err = savePipelineData(ctx, pipelineData)
+		if err != nil {
+			log.Printf("[ERROR] Failed to save the pipeline with trigger id: %s into the db: %s", pipeline.TriggerId, err)
+			resp.WriteHeader(500)
+			resp.Write([]byte(`{"success": false}`))
+			return
+		}
+		log.Printf("[INFO] Successfully saved the pipeline info")
 	}
 
 	err = SetWorkflowQueue(ctx, execRequest, parsedId)
@@ -157,7 +177,6 @@ func HandleNewPipelineRegister(resp http.ResponseWriter, request *http.Request) 
 		return
 	}
 
-	pipelineId := "test"
 	resp.WriteHeader(200)
-	resp.Write([]byte(fmt.Sprintf(`{"success": true, "reason": "Pipeline created", "id": "%s"}`, pipelineId)))
+	resp.Write([]byte(fmt.Sprintf(`{"success": true, "reason": "Pipeline will be created"}`)))
 }

--- a/structs.go
+++ b/structs.go
@@ -15,13 +15,53 @@ type AppContext struct {
 }
 
 type PipelineRequest struct {
-	Name        string `json:"name"`
-	Type        string `json:"type"`
-	Command     string `json:"command"`
+	Name	   	string `json:"name"`
+	Type 		string `json:"type"`
+	Command		string `json:"command"`
 	Environment string `json:"environment"`
+	WorkflowId  string `json:"workflow_id"`
 
-	PipelineId string `json:"pipeline_id"`
-	TriggerId  string `json:"trigger_id"`
+	PipelineId 	string `json:"pipeline_id"`
+	TriggerId	string `json:"trigger_id"`
+}
+
+type Pipeline struct {
+	Name	   	string 		`json:"name"`
+	Type 		string 		`json:"type"`
+	Command		string 		`json:"command"`
+	Environment string 		`json:"environment"`
+	WorkflowId  string 		`json:"workflow_id"`
+	StartNode   string 		`json:"start_node"`
+	OrgId       string 		`json:"org_id"`
+	Status      string 		`json:"status"`
+	Errors      []string 	`json:"errors"`
+	
+	PipelineId 	string 		`json:"pipeline_id"`
+	TriggerId	string 		`json:"trigger_id"`
+}
+
+type PipelineWrapper struct {
+	Index  string   `json:"_index"`
+	Type   string   `json:"_type"`
+	ID     string   `json:"_id"`
+	Version int     `json:"_version"`
+	Found   bool    `json:"found"`
+	Source  Pipeline `json:"_source"`
+}
+
+type AllPipelinesWrapper struct {
+	Hits struct {
+		Total struct {
+			Value    int    `json:"value"`
+			Relation string `json:"relation"`
+		} `json:"total"`
+		Hits     []struct {
+			Index  string  `json:"_index"`
+			ID     string  `json:"_id"`
+			Score  float64 `json:"_score"`
+			Source Pipeline `json:"_source"`
+		} `json:"hits"`
+	} `json:"hits"`
 }
 
 type QueryInput struct {


### PR DESCRIPTION
**Changes made :**
- when creating a pipeline we will add the pipeline info in to the database before adding it into the workflow queue 
- parseId is modified so that so `GetWorkflowQueue`  will return all the execution requests which also includes requests for pipelines as well ( this might be a temporary fix ) 
- added `HandleSavePipelineInfo` when pipeline is deployed successfully this means that backend has to know that , this imp as triggers ui uses that status to conditonally render options for the user whether to start or stop the pipeline

