### PR TITLE
Backend logic for sigma rule management

### DIFF
--- a/db-connector.go
+++ b/db-connector.go
@@ -8979,7 +8979,7 @@ func SetFile(ctx context.Context, file File) error {
 
 func storeDisabledRules(ctx context.Context, file DisabledRules) error {
 
-	nameKey := "disabled_files"
+	nameKey := "disabled_rules"
 
 	if project.DbType == "opensearch" {
 		data, err := json.Marshal(file)
@@ -8988,7 +8988,7 @@ func storeDisabledRules(ctx context.Context, file DisabledRules) error {
 			return err
 		}
 
-		err = indexEs(ctx, nameKey,"0", data)
+		err = indexEs(ctx, nameKey, "0", data)
 		if err != nil {
 			return err
 		}

--- a/db-connector.go
+++ b/db-connector.go
@@ -8977,7 +8977,7 @@ func SetFile(ctx context.Context, file File) error {
 	return nil
 }
 
-func storeDisabledRules(ctx context.Context, file DisabledRules) error {
+func StoreDisabledRules(ctx context.Context, file DisabledRules) error {
 
 	nameKey := "disabled_rules"
 
@@ -9003,7 +9003,7 @@ func storeDisabledRules(ctx context.Context, file DisabledRules) error {
 	return nil
 }
 
-func getDisabledRules(ctx context.Context) (*DisabledRules, error) {
+func GetDisabledRules(ctx context.Context) (*DisabledRules, error) {
 	nameKey := "disabled_rules"
 	disabRules := &DisabledRules{}
 	if project.DbType == "opensearch" {

--- a/db-connector.go
+++ b/db-connector.go
@@ -6762,14 +6762,19 @@ func GetWorkflowQueue(ctx context.Context, id string, limit int) (ExecutionReque
 				log.Printf("[WARNING] Error parsing the response body: %s", err)
 				return ExecutionRequestWrapper{}, err
 			} else {
-				// Print the response status and error information.
-				log.Printf("[%s] %s: %s",
-					res.Status(),
-					e["error"].(map[string]interface{})["type"],
-					e["error"].(map[string]interface{})["reason"],
-				)
+				// Check if "error" key exists and is of the expected type
+				if errInfo, ok := e["error"].(map[string]interface{}); ok {
+					log.Printf("[%s] %s: %s",
+						res.Status(),
+						errInfo["type"],
+						errInfo["reason"],
+					)
+				} else {
+					log.Printf("[ERROR] Unexpected error format: %v", e["error"])
+				}
 			}
 		}
+		
 
 		if res.StatusCode != 200 && res.StatusCode != 201 {
 			return ExecutionRequestWrapper{}, errors.New(fmt.Sprintf("Bad statuscode: %d", res.StatusCode))

--- a/files.go
+++ b/files.go
@@ -863,10 +863,24 @@ func enableRule(file File) error {
 		return err
 	}
 
+	// Check if resp.Files is empty
+	if len(resp.Files) == 0 {
+		log.Printf("[INFO] No disabled rules found.")
+		return nil
+	}
+
+	found := false
 	for i, innerFile := range resp.Files {
 		if innerFile.Id == file.Id {
 			resp.Files = append(resp.Files[:i], resp.Files[i+1:]...)
+			found = true
+			break 
 		}
+	}
+
+	if !found {
+		log.Printf("[INFO] File with ID %s not found in disabled rules", file.Id)
+		return nil
 	}
 
 	err = storeDisabledRules(ctx, *resp)
@@ -874,9 +888,10 @@ func enableRule(file File) error {
 		return err
 	}
 
-	log.Printf("[INFO] file with ID %s is enabled successfully", file.Id)
+	log.Printf("[INFO] File with ID %s is enabled successfully", file.Id)
 	return nil
 }
+
 
 func HandleGetFileNamespace(resp http.ResponseWriter, request *http.Request) {
 	cors := HandleCors(resp, request)

--- a/files.go
+++ b/files.go
@@ -785,7 +785,7 @@ func HandleToggleRule(resp http.ResponseWriter, request *http.Request) {
 	}
 
 	resp.WriteHeader(200)
-	resp.Write([]byte(fmt.Sprintf(`{"success": true, "id": "%s"}`, fileId)))
+	resp.Write([]byte((`{"success": true}`)))
 }
 
 func HandleFolderToggle(resp http.ResponseWriter, request *http.Request) {

--- a/files.go
+++ b/files.go
@@ -649,7 +649,7 @@ func HandleGetSigmaRules(resp http.ResponseWriter, request *http.Request) {
 	}
 
 	var isTenzirAlive bool
-	if time.Now().Unix() > disabledRules.LastActive+30 {
+	if time.Now().Unix() > disabledRules.LastActive+10 {
 		isTenzirAlive = false
 	} else {
 		isTenzirAlive = true
@@ -773,7 +773,7 @@ func HandleToggleRule(resp http.ResponseWriter, request *http.Request) {
 	if action == "disable" {
 		execType = "DISABLE_SIGMA_FILE"
 	} else if action == "enable" {
-		execType = "CATEGORY_UPDATE"
+		execType = "ENABLE_SIGMA_FILE"
 	}
 
 	err = SetExecRequest(ctx, execType, file.Filename)
@@ -2452,7 +2452,7 @@ func HandleDownloadRemoteFiles(resp http.ResponseWriter, request *http.Request) 
 	resp.Write([]byte(fmt.Sprintf(`{"success": true}`)))
 }
 
-func HandleDownloadRemoteFiles2(resp http.ResponseWriter, request *http.Request) {
+func HandleEnhancedDownloadRemoteFiles(resp http.ResponseWriter, request *http.Request) {
 	cors := HandleCors(resp, request)
 	if cors {
 		return

--- a/files.go
+++ b/files.go
@@ -725,12 +725,19 @@ func HandleToggleRule(resp http.ResponseWriter, request *http.Request) {
 	} else if action == "enable" {
 		err := enableRule(*file)
 		if err != nil {
-			log.Printf("[ERROR] Failed to %s file", action)
-			resp.WriteHeader(500)
+			if err.Error() != "rules doesn't exist" {
+			log.Printf("[ERROR] Failed to %s file, reason: %s", action, err)
+			resp.WriteHeader(404)
 			resp.Write([]byte(`{"success": false}`))
 			return
+		} else {
+			log.Printf("[ERROR] Failed to %s file", action)
+				resp.WriteHeader(500)
+				resp.Write([]byte(`{"success": false}`))
+				return
 		}
 	}
+}
 
 	execType := fmt.Sprintf("%s_SIGMA_FILE", strings.ToUpper(action))
 

--- a/files.go
+++ b/files.go
@@ -6,10 +6,10 @@ package shuffle
 
 import (
 	"archive/zip"
-	"encoding/base64"
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -23,10 +23,11 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
 	"gopkg.in/yaml.v2"
 
-	uuid "github.com/satori/go.uuid"
 	"github.com/google/go-github/v28/github"
+	uuid "github.com/satori/go.uuid"
 )
 
 var basepath = os.Getenv("SHUFFLE_FILE_LOCATION")
@@ -534,6 +535,7 @@ func HandleGetSigmaRules(resp http.ResponseWriter, request *http.Request) {
 	})
 
 	type SigmaFileInfo struct {
+		FileName string  `json:"file_name" yaml:"file_name"`
 		RuleTitle   string `json:"title" yaml:"title"`
 		Description string `json:"description" yaml:"description"`
 		FileId      string `json:"file_id"`
@@ -629,6 +631,7 @@ func HandleGetSigmaRules(resp http.ResponseWriter, request *http.Request) {
 			}
 
 			rule.FileId = file.Id
+			rule.Filename = file.Filename
 			sigmaFileInfo = append(sigmaFileInfo, rule)
 		}
 	}

--- a/files.go
+++ b/files.go
@@ -526,9 +526,10 @@ func HandleGetSigmaRules(resp http.ResponseWriter, request *http.Request) {
 	})
 
 	type SigmaFileInfo struct {
-		RuleName    string `yaml:"rule"`
-		Description string `yaml:"description"`
-	}
+		RuleName    string `json:"rule" yaml:"rule"`
+		Description string `json:"description" yaml:"description"`
+		IsEnabled   bool `json:"is_enabled"`
+	}	
 
 	var sigmaFileInfo []SigmaFileInfo
 
@@ -592,6 +593,9 @@ func HandleGetSigmaRules(resp http.ResponseWriter, request *http.Request) {
 			if err != nil {
 				log.Printf("[ERROR] Failed to parse YAML file %s: %s", file.Filename, err)
 				continue
+			}
+			if file.Status == "active" {
+                rule.IsEnabled = true
 			}
 
 			sigmaFileInfo = append(sigmaFileInfo, rule)

--- a/files.go
+++ b/files.go
@@ -974,7 +974,8 @@ func HandleSaveSelectedRules(resp http.ResponseWriter, request *http.Request) {
 
 	triggerId := location[4]
 
-	var selectedRules SelectedSigmaRules
+	selectedRules := SelectedSigmaRules{}
+	
 	decoder := json.NewDecoder(request.Body)
 	err = decoder.Decode(&selectedRules)
 	if err != nil {
@@ -986,12 +987,10 @@ func HandleSaveSelectedRules(resp http.ResponseWriter, request *http.Request) {
 
 	err = StoreSelectedRules(request.Context(), triggerId, selectedRules)
 	if err != nil {
-		if err.Error() != "rules doesnt exists" {
 			log.Printf("[ERROR] Error storing selected rules for %s: %s", triggerId, err)
 			resp.WriteHeader(http.StatusInternalServerError)
 			resp.Write([]byte(`{"success": false}`))
 			return
-		}
 	}
 
 	responseData, err := json.Marshal(selectedRules)

--- a/files.go
+++ b/files.go
@@ -522,7 +522,7 @@ func HandleGetSigmaRules(resp http.ResponseWriter, request *http.Request) {
 	}
 
 	disabledRules, err := getDisabledRules(ctx)
-	if err != nil {
+	if err.Error() != "rules doesn't exist" {
 		log.Printf("[ERROR] Failed to get disabled rules: %s", err)
 		resp.WriteHeader(500)
 		resp.Write([]byte(`{"success": false, "reason": "Error getting disabled rules."}`))

--- a/files.go
+++ b/files.go
@@ -756,7 +756,7 @@ func HandleToggleRule(resp http.ResponseWriter, request *http.Request) {
 		execType = "CATEGORY_UPDATE"
 	}
 
-	err = setExecRequest(ctx, execType, file.Filename)
+	err = SetExecRequest(ctx, execType, file.Filename)
 	if err != nil {
 		log.Printf("[ERROR] Failed setting workflow queue for env: %s", err)
 		resp.WriteHeader(500)
@@ -819,7 +819,7 @@ func HandleFolderToggle(resp http.ResponseWriter, request *http.Request) {
 		execType = "CATEGORY_UPDATE"
 	}
 
-	err = setExecRequest(ctx, execType, "")
+	err = SetExecRequest(ctx, execType, "")
 	if err != nil {
 		log.Printf("[ERROR] Failed setting workflow queue for env: %s", err)
 		resp.WriteHeader(500)
@@ -1345,7 +1345,7 @@ func HandleGetFileNamespace(resp http.ResponseWriter, request *http.Request) {
 	io.Copy(resp, buf)
 }
 
-func setExecRequest(ctx context.Context, execType string, fileName string) error {
+func SetExecRequest(ctx context.Context, execType string, fileName string) error {
 
 	execRequest := ExecutionRequest{
 		Type:              execType,
@@ -1758,7 +1758,7 @@ func HandleEditFile(resp http.ResponseWriter, request *http.Request) {
 	log.Printf("[INFO] Successfully edited file ID %s", file.Id)
 
 	execType := "CATEGORY_UPDATE"
-	err = setExecRequest(ctx, execType, file.Filename)
+	err = SetExecRequest(ctx, execType, file.Filename)
 	if err != nil {
 		log.Printf("[ERROR] Failed setting workflow queue for env: %s", err)
 		resp.WriteHeader(500)
@@ -1906,15 +1906,16 @@ func HandleUploadFile(resp http.ResponseWriter, request *http.Request) {
 	}
 
 	log.Printf("[INFO] Successfully uploaded file ID %s", file.Id)
-
+  
+	if file.Namespace == "sigma" {
 	execType := "CATEGORY_UPDATE"
-	err = setExecRequest(ctx, execType, file.Filename)
+	err = SetExecRequest(ctx, execType, file.Filename)
 	if err != nil {
 		log.Printf("[ERROR] Failed setting workflow queue for env: %s", err)
 		resp.WriteHeader(500)
 		resp.Write([]byte(`{"success": false}`))
 		return
-	}
+	}}
 
 	resp.WriteHeader(200)
 	resp.Write([]byte(fmt.Sprintf(`{"success": true, "file_id": "%s"}`, fileId)))

--- a/shared.go
+++ b/shared.go
@@ -4603,6 +4603,42 @@ func HandleGetHooks(resp http.ResponseWriter, request *http.Request) {
 	resp.Write(newjson)
 }
 
+func HandleConnectSiem(resp http.ResponseWriter, request *http.Request) {
+	cors := HandleCors(resp, request)
+	if cors {
+		return
+	}
+
+	user, err := HandleApiAuthentication(resp, request)
+	if err != nil {
+		log.Printf("[WARNING] Api authentication failed in conenct siem: %s", err)
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	if user.Role == "org-reader" {
+		resp.WriteHeader(401)
+		resp.Write([]byte(`{"success": false, "reason": "org reader dont have permission"}`))
+		return
+	}
+
+	ctx := GetContext(request)
+	execType := "START_TENZIR"
+	err = SetExecRequest(ctx, execType, "")
+	if err != nil {
+		log.Printf("[ERROR] Failed setting workflow queue for env: %s", err)
+		resp.WriteHeader(500)
+		resp.Write([]byte(`{"success": false}`))
+		return
+	}
+
+	resp.WriteHeader(200)
+	resp.Write([]byte(`{"success": true}`))
+
+
+}
+
 func HandleUpdateUser(resp http.ResponseWriter, request *http.Request) {
 	cors := HandleCors(resp, request)
 	if cors {

--- a/structs.go
+++ b/structs.go
@@ -1393,7 +1393,19 @@ type DisabledRules struct {
 	Files          []File  `json:"files"        datastore:"files"`
 	DisabledFolder bool    `json:"disabled_folder" datastore:"disabled_folder"`
 	IsTenzirActive string    `json:"tenzir_active"  datastore:"tenzir_active"`
-	LastActive     string  `json:"last_active" datastore:"last_active"`
+	LastActive     int64  `json:"last_active" datastore:"last_active"`
+}
+
+type SelectedSigmaRules struct {
+     SelectedRules []SigmaFileInfo  `json:"selected_rules" datastore:"selected_rules"`
+}
+
+type SigmaFileInfo struct {
+	FileName string  `json:"file_name" yaml:"file_name"`
+	RuleTitle   string `json:"title" yaml:"title"`
+	Description string `json:"description" yaml:"description"`
+	FileId      string `json:"file_id"`
+	IsEnabled   bool   `json:"is_enabled"`
 }
 
 type AppAuthenticationGroup struct {
@@ -2367,6 +2379,17 @@ type DisabledHookWrapper struct {
 	PrimaryTerm int           `json:"_primary_term"`
 	Found       bool          `json:"found"`
 	Source      DisabledRules `json:"_source"`
+}
+
+type SelectedRulesWrapper struct {
+	Index       string        `json:"_index"`
+	Type        string        `json:"_type"`
+	ID          string        `json:"_id"`
+	Version     int           `json:"_version"`
+	SeqNo       int           `json:"_seq_no"`
+	PrimaryTerm int           `json:"_primary_term"`
+	Found       bool          `json:"found"`
+	Source      SelectedSigmaRules `json:"_source"`
 }
 
 type HookWrapper struct {

--- a/structs.go
+++ b/structs.go
@@ -1390,8 +1390,10 @@ type File struct {
 }
 
 type DisabledRules struct {
-	Files          []File `json:"files" datastore:"files"`
-	DisabledFolder bool   `json:"disabled_folder" datastore:"disabled_folder"`
+	Files          []File  `json:"files"        datastore:"files"`
+	DisabledFolder bool    `json:"disabled_folder" datastore:"disabled_folder"`
+	IsTenzirActive string    `json:"tenzir_active"  datastore:"tenzir_active"`
+	LastActive     string  `json:"last_active" datastore:"last_active"`
 }
 
 type AppAuthenticationGroup struct {

--- a/structs.go
+++ b/structs.go
@@ -1389,6 +1389,11 @@ type File struct {
 	OriginalMd5sum  string   `json:"Originalmd5_sum" datastore:"Originalmd5_sum"`
 }
 
+type DisabledRules struct {
+	Files []File  `json:"files" datastore:"files"`
+	DisabledFolder bool `json:"disabled_folder" datastore:"disabled_folder"`
+}
+
 type AppAuthenticationGroup struct {
 	Active			bool                  `json:"active" datastore:"active"`
 	Label			string                `json:"label" datastore:"label"`
@@ -2349,6 +2354,17 @@ type FileWrapper struct {
 	PrimaryTerm int    `json:"_primary_term"`
 	Found       bool   `json:"found"`
 	Source      File   `json:"_source"`
+}
+
+type DisabledHookWrapper struct {
+	Index       string          `json:"_index"`
+	Type        string			`json:"_type"`
+	ID          string 			`json:"_id"`
+	Version     int   		    `json:"_version"`
+	SeqNo       int   			`json:"_seq_no"`
+	PrimaryTerm int    			`json:"_primary_term"`
+	Found       bool            `json:"found"`
+	Source      DisabledRules   `json:"_source"`
 }
 
 type HookWrapper struct {

--- a/structs.go
+++ b/structs.go
@@ -21,6 +21,7 @@ type PipelineRequest struct {
 	Environment string `json:"environment"`
 	WorkflowId  string `json:"workflow_id"`
 	StartNode   string `json:"start_node"`
+	Url         string `json:"url"`
 
 	PipelineId 	string `json:"pipeline_id"`
 	TriggerId	string `json:"trigger_id"`

--- a/structs.go
+++ b/structs.go
@@ -1390,8 +1390,8 @@ type File struct {
 }
 
 type DisabledRules struct {
-	Files []File  `json:"files" datastore:"files"`
-	DisabledFolder bool `json:"disabled_folder" datastore:"disabled_folder"`
+	Files          []File `json:"files" datastore:"files"`
+	DisabledFolder bool   `json:"disabled_folder" datastore:"disabled_folder"`
 }
 
 type AppAuthenticationGroup struct {
@@ -2357,14 +2357,14 @@ type FileWrapper struct {
 }
 
 type DisabledHookWrapper struct {
-	Index       string          `json:"_index"`
-	Type        string			`json:"_type"`
-	ID          string 			`json:"_id"`
-	Version     int   		    `json:"_version"`
-	SeqNo       int   			`json:"_seq_no"`
-	PrimaryTerm int    			`json:"_primary_term"`
-	Found       bool            `json:"found"`
-	Source      DisabledRules   `json:"_source"`
+	Index       string        `json:"_index"`
+	Type        string        `json:"_type"`
+	ID          string        `json:"_id"`
+	Version     int           `json:"_version"`
+	SeqNo       int           `json:"_seq_no"`
+	PrimaryTerm int           `json:"_primary_term"`
+	Found       bool          `json:"found"`
+	Source      DisabledRules `json:"_source"`
 }
 
 type HookWrapper struct {


### PR DESCRIPTION
**Description :**
This PR adds the backend logic to enable/disable sigma rules 

**Things Added :** 
1. `HandleGetSigmaRules` this function will fetch the sigma rules from db (meta data)
2. `HandleEnhancedDownloadRemoteFiles` a new handler function that is used to download the sigma rules from a github repo
3. `HandleConnectSiem` is used to spin up the tenzir node
4. `HandleToggleRule` and `HandleFolderToggle` are used to enable/disable sigma rule files

**Whats Changed ?**
- When ever some one uploads or edit a file which is under the `sigma` namespace  then the orborus will be notified about the change 

**Related PR's**
- https://github.com/Shuffle/Shuffle/pull/1459