### PR TITLE
Fixing SHUFFLE_INTERNAL_PROXY

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -23615,6 +23615,7 @@ func GetExternalClient(baseUrl string) *http.Client {
 	httpProxy := os.Getenv("SHUFFLE_INTERNAL_HTTP_PROXY")
 	httpsProxy := os.Getenv("SHUFFLE_INTERNAL_HTTPS_PROXY")
 
+
 	transport := http.DefaultTransport.(*http.Transport)
 	transport.MaxIdleConnsPerHost = 100
 	transport.ResponseHeaderTimeout = time.Second * 60
@@ -23671,7 +23672,7 @@ func GetExternalClient(baseUrl string) *http.Client {
 
 	if (len(httpProxy) > 0 || len(httpsProxy) > 0) && baseUrl != "http://shuffle-backend:5001" {
 		//client = &http.Client{}
-        if len(httpProxy) > 0 {
+        if len(httpProxy) > 0 && httpProxy != "noproxy"{
 			log.Printf("[INFO] Running with HTTP proxy %s (env: HTTP_PROXY)", httpProxy)
 
 			url_i := url.URL{}
@@ -23680,7 +23681,7 @@ func GetExternalClient(baseUrl string) *http.Client {
 				transport.Proxy = http.ProxyURL(url_proxy)
 			}
 		}
-		if len(httpsProxy) > 0 {
+		if len(httpsProxy) > 0 && httpsProxy != "noproxy"{
 			log.Printf("[INFO] Running with HTTPS proxy %s (env: HTTPS_PROXY)", httpsProxy)
 
 			url_i := url.URL{}
@@ -23691,7 +23692,7 @@ func GetExternalClient(baseUrl string) *http.Client {
 		}
 	} else {
         // keeping this here for now
-		if len(httpProxy) > 0 {
+		if len(httpProxy) > 0 && httpProxy != "noproxy" {
 			log.Printf("[INFO] Running with HTTP proxy %s (env: HTTP_PROXY)", httpProxy)
 
 			url_i := url.URL{}
@@ -23700,7 +23701,7 @@ func GetExternalClient(baseUrl string) *http.Client {
 				transport.Proxy = http.ProxyURL(url_proxy)
 			}
 		}
-		if len(httpsProxy) > 0 {
+		if len(httpsProxy) > 0 && httpsProxy != "noproxy" {
 			log.Printf("[INFO] Running with HTTPS proxy %s (env: HTTPS_PROXY)", httpsProxy)
 
 			url_i := url.URL{}

--- a/shared_test.go
+++ b/shared_test.go
@@ -2,6 +2,7 @@ package shuffle
 
 import (
     "testing"
+    "net/http"
 )
 
 func TestIsLoop(t *testing.T) {
@@ -25,4 +26,18 @@ func TestIsLoop(t *testing.T) {
             t.Errorf("isLoop(%s) = %v; expected %v", tt.arg, result, tt.expected)
         }
     }
+}
+
+// Simple Test for HandleInternalProxy(client)
+// set env SHUFFLE_INTERNAL_HTTP_PROXY to test the function.
+func TestHandleInternalProxy(t *testing.T) {
+	client := &http.Client{}
+	result := HandleInternalProxy(client)
+
+	if result.Transport.(*http.Transport).Proxy != nil {
+		proxyURL, _ := result.Transport.(*http.Transport).Proxy(nil)
+		t.Logf("Proxy URL set: %v", proxyURL)
+	} else {
+		t.Log("No proxy set")
+	}
 }


### PR DESCRIPTION
Not ready yet as I have lost the ability of NOPROXY for SHUFFLE_INTERNAL_PROXY var. But the initial test seems to work for my simple initial test. Will make more changes with getting for test done. 

From my simple python proxy:
![Screenshot 2024-08-21 211334](https://github.com/user-attachments/assets/204988b5-26ba-4eda-b146-eeeac024176a)


From Orborus:
![Screenshot 2024-08-21 210954](https://github.com/user-attachments/assets/a52a07a1-2d8e-4750-869a-518e16518583)

Ran a workflow: 
![Screenshot 2024-08-21 211032](https://github.com/user-attachments/assets/462b534c-5691-49fa-8d52-a04f02df6642)



Need to look at worker and app log. 

@frikky Please let me know if there is anything I'm missing for doing wrong :)