### PR TITLE
Statistics counting issue with a time based solution

### DIFF
--- a/db-connector.go
+++ b/db-connector.go
@@ -53,7 +53,7 @@ var maxCacheSize = 1020000
 
 // var dbInterval = 0x19
 // var dbInterval = 0x1
-var dbInterval = 25
+var dbInterval = 500
 // var dbInterval = 0xA
 
 // Dumps data from cache to DB for every {dbInterval} action (tried 5, 10, 25)
@@ -595,6 +595,56 @@ func IncrementCache(ctx context.Context, orgId, dataType string, amount ...int) 
 	dbDumpInterval := uint8(dbInterval)
 	key := fmt.Sprintf("cache_%s_%s", orgId, dataType)
 	if len(memcached) > 0 {
+		// check if the cache already key is indexed in memcache
+		keyItems, err := mc.Get("stat_cache_keys_" + orgId)
+		if err == gomemcache.ErrCacheMiss {
+			keyItem := []string{key}
+			data, err := json.Marshal(keyItem)
+			if err != nil {
+				log.Printf("[ERROR] Failed marshalling increment item for cache: %s", err)
+			} else {
+				// dump it to memcache
+				item := &gomemcache.Item{
+					Key:        "stat_cache_keys_" + orgId,
+					Value:      data,
+					Expiration: 86400*30,
+				}
+
+				if err := mc.Set(item); err != nil {
+					log.Printf("[ERROR] Failed setting increment cache for key %s: %s", orgId, err)
+				} else {
+					log.Printf("[DEBUG] Set cache index key for (1) %s", orgId)
+				}
+			}
+		} else {
+			dumpedItems := []string{}
+			err = json.Unmarshal(keyItems.Value, &dumpedItems)
+			if err != nil {
+				log.Printf("[ERROR] Failed unmarshalling item in cache: %s", err)
+			} else {
+				if !ArrayContains(dumpedItems, key) {
+					dumpedItems = append(dumpedItems, key)
+					data, err := json.Marshal(dumpedItems)
+					if err != nil {
+						log.Printf("[ERROR] Failed marshalling increment item for cache: %s", err)
+					} else {
+						// dump it to memcache
+						item := &gomemcache.Item{
+							Key:        "stat_cache_keys_" + orgId,
+							Value:      data,
+							Expiration: 86400*30,
+						}
+
+						if err := mc.Set(item); err != nil {
+							log.Printf("[ERROR] Failed setting increment cache for key %s: %s", orgId, err)
+						} else {
+							log.Printf("[DEBUG] Set cache index key for (1) %s", orgId)
+						}
+					}
+				}
+			}
+		}
+
 		item, err := mc.Get(key)
 		if err == gomemcache.ErrCacheMiss {
 			incrementItem := IncrementInCache{

--- a/db-connector.go
+++ b/db-connector.go
@@ -868,7 +868,7 @@ func IncrementCache(ctx context.Context, orgId, dataType string, amount ...int) 
 				}
 			} else {
 				// let's keep this here for now
-				log.Printf("[ERROR] Length of value in cache key %s is longer than 1: %d", key, len(item.Value))
+				// log.Printf("[ERROR] Length of value in cache key %s is less than 1: %d", key, len(item.Value))
 			}
 		}
 

--- a/db-connector.go
+++ b/db-connector.go
@@ -53,7 +53,8 @@ var maxCacheSize = 1020000
 
 // var dbInterval = 0x19
 // var dbInterval = 0x1
-var dbInterval = 0xA
+var dbInterval = 25
+// var dbInterval = 0xA
 
 // Dumps data from cache to DB for every {dbInterval} action (tried 5, 10, 25)
 
@@ -700,7 +701,7 @@ func IncrementCache(ctx context.Context, orgId, dataType string, amount ...int) 
 				// (10-60 seconds)
 				randomSeconds := (rand.Intn(50) + 10)*5 // to make the number longer
 		
-				if time.Now().Unix()-incrementedItemInCache.CreatedAt > int64(randomSeconds) && incrementedItemInCache.Amount > 25 {
+				if time.Now().Unix()-incrementedItemInCache.CreatedAt > int64(randomSeconds) && incrementedItemInCache.Amount > uint64(dbInterval) {
 					// Memcache dump first to keep the counter going for other executions
 					oldNum := num
 					num = 0

--- a/db-connector.go
+++ b/db-connector.go
@@ -162,7 +162,7 @@ func handleDailyCacheUpdate(executionInfo *ExecutionInfo) *ExecutionInfo {
 	return executionInfo
 }
 
-func HandleIncrement(dataType string, orgStatistics *ExecutionInfo, increment uint8) *ExecutionInfo {
+func HandleIncrement(dataType string, orgStatistics *ExecutionInfo, increment uint) *ExecutionInfo {
 
 	appendCustom := false
 	if dataType == "app_executions" || strings.HasPrefix(dataType, "app_executions") {
@@ -401,10 +401,10 @@ func IncrementCacheDump(ctx context.Context, orgId, dataType string, amount ...i
 	nameKey := "org_statistics"
 	orgStatistics := &ExecutionInfo{}
 
-	dbDumpInterval := uint8(dbInterval)
+	dbDumpInterval := uint(dbInterval)
 	if len(amount) > 0 {
 		if amount[0] > 0 {
-			dbDumpInterval = uint8(amount[0])
+			dbDumpInterval = uint(amount[0])
 		}
 	}
 

--- a/db-connector.go
+++ b/db-connector.go
@@ -613,7 +613,7 @@ func IncrementCache(ctx context.Context, orgId, dataType string, amount ...int) 
 				if err := mc.Set(item); err != nil {
 					log.Printf("[ERROR] Failed setting increment cache for key %s: %s", orgId, err)
 				} else {
-					log.Printf("[DEBUG] Set cache index key for (1) %s", orgId)
+					// log.Printf("[DEBUG] Set cache index key for (1) %s", orgId)
 				}
 			}
 		} else {
@@ -638,7 +638,7 @@ func IncrementCache(ctx context.Context, orgId, dataType string, amount ...int) 
 						if err := mc.Set(item); err != nil {
 							log.Printf("[ERROR] Failed setting increment cache for key %s: %s", orgId, err)
 						} else {
-							log.Printf("[DEBUG] Set cache index key for (1) %s", orgId)
+							// log.Printf("[DEBUG] Set cache index key for (1) %s", orgId)
 						}
 					}
 				}
@@ -689,7 +689,7 @@ func IncrementCache(ctx context.Context, orgId, dataType string, amount ...int) 
 					Expiration: 86400*30,
 				}
 
-				log.Printf("[ERROR] Value in DB is nil for cache %s.", dataType)
+				// log.Printf("[ERROR] Value in DB is nil for cache %s.", dataType)
 			}
 
 			if len(item.Value) == 1 {
@@ -742,7 +742,7 @@ func IncrementCache(ctx context.Context, orgId, dataType string, amount ...int) 
 
 				incrementedItemInCache.Amount = num
 
-				log.Printf("[DEBUG] time.Now().Unix() (%d) - incrementedItemInCache.CreatedAt (%d) = %d", time.Now().Unix(), incrementedItemInCache.CreatedAt, time.Now().Unix()-incrementedItemInCache.CreatedAt)
+				// log.Printf("[DEBUG] time.Now().Unix() (%d) - incrementedItemInCache.CreatedAt (%d) = %d", time.Now().Unix(), incrementedItemInCache.CreatedAt, time.Now().Unix()-incrementedItemInCache.CreatedAt)
 
 				// if num >= dbDumpInterval {
 				// if the cache was created more than a day ago
@@ -759,7 +759,7 @@ func IncrementCache(ctx context.Context, orgId, dataType string, amount ...int) 
 					incrementedItemInCache.Amount = num
 					incrementedItemInCache.CreatedAt = time.Now().Unix()
 
-					log.Printf("[DEBUG] Dumping cache item with key %s which was created at %s is was %d", key, incrementedItemInCache.CreatedAt, oldNum)
+					// log.Printf("[DEBUG] Dumping cache item with key %s which was created at %s is was %d", key, incrementedItemInCache.CreatedAt, oldNum)
 
 					data, err := json.Marshal(incrementedItemInCache)
 					if err != nil {
@@ -772,7 +772,7 @@ func IncrementCache(ctx context.Context, orgId, dataType string, amount ...int) 
 					if err != nil {
 						log.Printf("[ERROR] Failed dumping cache for key (1) %s: %s", key, err)
 						if strings.Contains(fmt.Sprintf("%s", err), "concurrent transaction") {
-							log.Printf("[ERROR] Concurrent transaction in cache dump: %s. Storing in cache (%s) instead with new amount: %d", err, key, oldNum)
+							// log.Printf("[ERROR] Concurrent transaction in cache dump: %s. Storing in cache (%s) instead with new amount: %d", err, key, oldNum)
 							incrementedItemInCache.Amount = oldNum
 							
 							data, err := json.Marshal(incrementedItemInCache)
@@ -842,7 +842,7 @@ func IncrementCache(ctx context.Context, orgId, dataType string, amount ...int) 
 					}
 
 					// log.Printf("[DEBUG] Cache item with key %s which was created at %d is now %d", key, incrementedItemInCache.CreatedAt, incrementedItemInCache.Amount)
-					log.Printf("[DEBUG] Cache item with key %s which was created at %d is now %d. While num we updated was %d", key, incrementedItemInCache.CreatedAt, incrementedItemInCache.Amount, num)
+					// log.Printf("[DEBUG] Cache item with key %s which was created at %d is now %d. While num we updated was %d", key, incrementedItemInCache.CreatedAt, incrementedItemInCache.Amount, num)
 
 					data, err := json.Marshal(incrementedItemInCache)
 					if err != nil {

--- a/stats.go
+++ b/stats.go
@@ -535,7 +535,7 @@ func HandleGetStatistics(resp http.ResponseWriter, request *http.Request) {
 	if len(memcached) > 0 {
 		keysInterface, err := GetCache(ctx, "stat_cache_keys_" + orgId)
 		if err != nil {
-			log.Printf("[WARNING] Failed getting cache keys for org %s: %s", orgId, err)
+			// log.Printf("[WARNING] Failed getting cache keys for org %s: %s", orgId, err)
 		} else {
 			var keys []string
 
@@ -566,7 +566,7 @@ func HandleGetStatistics(resp http.ResponseWriter, request *http.Request) {
 
 					// Increment the value
 					if !(len(valueBytes) > 1) {
-						log.Printf("[WARNING] Invalid value for key %s: %s", key, value)
+						// log.Printf("[WARNING] Invalid value for key %s: %s", key, value)
 						continue
 					}
 
@@ -578,7 +578,7 @@ func HandleGetStatistics(resp http.ResponseWriter, request *http.Request) {
 					}
 
 					if incrementInCache.Amount == 0 {
-						log.Printf("[INFO] No need to dump cache value for key %s", key)
+						// log.Printf("[INFO] No need to dump cache value for key %s", key)
 						continue
 					}
 
@@ -594,7 +594,7 @@ func HandleGetStatistics(resp http.ResponseWriter, request *http.Request) {
 					if err != nil {
 						log.Printf("[WARNING] Failed dumping cache value for key %s: %s and datatype %s", key, err, dataType)
 					} else {
-						log.Printf("[INFO] Dumped cache value for key %s and datatype %s", key, dataType)
+						// log.Printf("[INFO] Dumped cache value for key %s and datatype %s", key, dataType)
 						// now, set it back to 0
 						incrementInCache.Amount = 0
 						incrementInCache.CreatedAt = time.Now().Unix()

--- a/stats.go
+++ b/stats.go
@@ -572,10 +572,10 @@ func HandleGetStatistics(resp http.ResponseWriter, request *http.Request) {
 		for _, dataType := range PredictableDataTypes {
 			key := fmt.Sprintf("cache_%s_%s", orgId, dataType)
 			if !ArrayContains(keys, key) {
-				log.Printf("[DEBUG] Adding %s to stats", key)
+				// log.Printf("[DEBUG] Adding %s to stats", key)
 				keys = append(keys, key)
 			} else {
-				log.Printf("[DEBUG] NOT Adding %s to stats because they are apparently in %+v", keys)	
+				// log.Printf("[DEBUG] NOT Adding %s to stats because they are apparently in %+v", keys)	
 			}
 		}
 
@@ -620,8 +620,10 @@ func HandleGetStatistics(resp http.ResponseWriter, request *http.Request) {
 				if err != nil {
 					log.Printf("[WARNING] Failed dumping cache value for key %s: %s and datatype %s", key, err, dataType)
 				} else {
-					log.Printf("[INFO] Dumped cache value for key %s and datatypes %s", key, dataType)
+					// log.Printf("[INFO] Dumped cache value for key %s and datatypes %s", key, dataType)
 					// now, set it back to 0
+					// known bug: many times, the cache just deletes
+					// rather than becoming 0
 					incrementInCache.Amount = 0
 					incrementInCache.CreatedAt = time.Now().Unix()
 

--- a/stats.go
+++ b/stats.go
@@ -588,13 +588,13 @@ func HandleGetStatistics(resp http.ResponseWriter, request *http.Request) {
 						continue
 					}
 
-					dataType := strings.Split(key, "_")[2]
+					dataType := strings.Join(strings.Split(key, "_")[2:], "_")
 
 					err = IncrementCacheDump(ctx, orgId, dataType, int(incrementInCache.Amount))
 					if err != nil {
-						log.Printf("[WARNING] Failed dumping cache value for key %s: %s", key, err)
+						log.Printf("[WARNING] Failed dumping cache value for key %s: %s and datatype %s", key, err, dataType)
 					} else {
-						log.Printf("[INFO] Dumped cache value for key %s", key)
+						log.Printf("[INFO] Dumped cache value for key %s and datatype %s", key, dataType)
 						// now, set it back to 0
 						incrementInCache.Amount = 0
 						incrementInCache.CreatedAt = time.Now().Unix()

--- a/structs.go
+++ b/structs.go
@@ -348,6 +348,11 @@ type AppUsage struct {
 	Usage   int64  `json:"usage" datastore:"usage"`
 }
 
+type IncrementInCache struct {
+	Amount uint64 `json:"amount" datastore:"amount"`
+	CreatedAt int64 `json:"created_at" datastore:"created_at"`
+}
+
 // Should be for a particular day
 // Reset is handled during caching. If the date is not today, then the reset is handled
 type DailyStatistics struct {


### PR DESCRIPTION
Missed 1 out of 25 incrementation made for statistics if 25 workflows are started at the same second due to cache overwrites.

Most pragmatic solution that should work at our scale better than our current implementation.

## Small things to change
- ~Remember to remove unnecessary logging before shipping.~ Done
- Maybe make use of uint16 instead of uint64 for the increments stored in cache?
- ~Replace the use of uint8 in the increment functions. Might cause weird bugs later on.~ Done

## Things to add
- ~Add hotloading feature~ Done