### PR TITLE
few seconds threshold for execution

### DIFF
--- a/health.go
+++ b/health.go
@@ -987,7 +987,7 @@ func RunOpsWorkflow(apiKey string, orgId string) (WorkflowHealth, error) {
 	}
 
 	updateOpsCache(workflowHealth)
-	timeout := time.After(5 * time.Minute)
+	timeout := time.After(6 * time.Minute)
 
 	if workflowHealth.Create == true {
 		log.Printf("[DEBUG] Deleting created ops workflow")


### PR DESCRIPTION
This pr makes the health page graphs goes green.

The logs represent the only reason behind the `run_finished: false` are this few seconds. Please merge.