### PR TITLE
[fix]: returning the same apps for the user

### DIFF
--- a/db-connector.go
+++ b/db-connector.go
@@ -6969,6 +6969,7 @@ func GetUserApps(ctx context.Context, userId string) ([]WorkflowApp, error) {
 				for {
 					innerApp := WorkflowApp{}
 					_, err = it.Next(&innerApp)
+					alreadyExists := false
 					//log.Printf("Got app: %s (%s)", innerApp.Name, innerApp.ID)
 					cnt += 1
 					if cnt > maxAmount {
@@ -6999,8 +7000,16 @@ func GetUserApps(ctx context.Context, userId string) ([]WorkflowApp, error) {
 						continue
 					}
 
-					userApps = append(userApps, innerApp)
+					// Not sure if it actually make the API slower
+					for _, app := range userApps {
+						if app.ID == innerApp.ID {
+							alreadyExists = true
+						}
+					}
 
+					if !alreadyExists {
+						userApps = append(userApps, innerApp)
+					}
 				}
 
 				if err != nil {


### PR DESCRIPTION
Since the owner can be the contributor, getting same apps make sense. Since it run them as an individual query.   