### PR TITLE
ResetCache option for articles list

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -19035,15 +19035,20 @@ func GetArticlesList(resp http.ResponseWriter, request *http.Request) {
 
 	ctx := GetContext(request)
 	cacheKey := "articles_list"
+	resetCache := request.URL.Query().Get("resetCache") == "true" // Check for resetCache parameter
+
+	if !resetCache {
 	cache, err := GetCache(ctx, cacheKey)
-	result := FileList{}
 	if err == nil {
 		cacheData := []byte(cache.([]uint8))
 		resp.WriteHeader(200)
 		resp.Write(cacheData)
 		return
+		}
 	}
-
+	result := FileList{}
+	log.Println("[DEBUG] Skipping Cache for Articles List")
+	
 	client := github.NewClient(nil)
 	owner := "shuffle"
 	repo := "shuffle-docs"


### PR DESCRIPTION
Is this the correct approach?
Passing the resetCache parameter in the query when it's false, returning the cached data, and when it's true (triggered when a support user clicks 'Reset Cache' button on top of Table of content), skipping the cache retrieval and fetching a new article list, then updating the cache with the new data.