### PR TITLE
removed github backup info from the json file

### DIFF
--- a/cloudSync.go
+++ b/cloudSync.go
@@ -887,6 +887,9 @@ func SetGitWorkflow(ctx context.Context, workflow Workflow, org *Org) error {
 		workflow.Triggers[triggerIndex].SmallImage = ""
 	}
 
+	// remove github backup info
+	workflow.BackupConfig = BackupConfig{}
+
 	// Use git to upload the workflow. 
 	workflowData, err := json.MarshalIndent(workflow, "", "  ")
 	if err != nil {


### PR DESCRIPTION
I think we should, also add some kind of warning in the frontend - informing user that there workflow could contain sensitive data and pushing them to public repo can create problems.

We can remove sensitive information from the action, but then it won't be a proper backup.