### PR TITLE
Load public workflow from main region when fail to load in other region

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -9630,7 +9630,7 @@ func GetSpecificWorkflow(resp http.ResponseWriter, request *http.Request) {
 
 	ctx := GetContext(request)
 	workflow, err := GetWorkflow(ctx, fileId)
-	if err != nil {
+	if err != nil || len(workflow.ID) == 0 {
 		if project.Environment == "cloud" {
 			gceProject := os.Getenv("SHUFFLE_GCEPROJECT")
 			if gceProject != "shuffler" && gceProject != sandboxProject && len(gceProject) > 0 {


### PR DESCRIPTION
When a public workflow is not available in another region, get it from the main region. Currently, when a public workflow is not available in the Frankfurt or Canada regions, no error is thrown, so no request is sent to get it from the main region. As a result, it always fails to load the workflow in other regions.

Issue: https://github.com/Shuffle/Shuffle/issues/1696

@0x0elliot 