### PR TITLE
Keep context of the distributed workflow env

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -6381,8 +6381,9 @@ func diffWorkflows(oldWorkflow Workflow, parentWorkflow Workflow, update bool) {
 		log.Printf("[ERROR][%s] Failed to get distributed workflow environments: %s", oldWorkflow.OrgId, err)
 	}
 
-	// Check if environment is even distributed or not
-	// if not do we need to change the env?
+	// Keep the environment unchanged for the
+	// distributed workflow if the parent workflow runtime enviroment
+	// does not exist.
 	for _, action := range oldWorkflow.Actions {
 		if strings.ToLower(parentWorkflowEnvironment) == "cloud" {
 			discoveredEnvironment = parentWorkflowEnvironment

--- a/shared.go
+++ b/shared.go
@@ -6385,6 +6385,8 @@ func diffWorkflows(oldWorkflow Workflow, parentWorkflow Workflow, update bool) {
 	// distributed workflow if the parent workflow runtime enviroment
 	// does not exist.
 	for _, action := range oldWorkflow.Actions {
+		// Change all the distributed workflow to cloud if
+		// parent workflow runtime changes to cloud.
 		if strings.ToLower(parentWorkflowEnvironment) == "cloud" {
 			discoveredEnvironment = parentWorkflowEnvironment
 			break

--- a/shared.go
+++ b/shared.go
@@ -6322,6 +6322,7 @@ func diffWorkflows(oldWorkflow Workflow, parentWorkflow Workflow, update bool) {
 
 	// We create a new ID for each trigger.
 	// Older ID is stored in trigger.ReplacementForTrigger
+	ctx := context.Background()
 	nameChanged := false
 	descriptionChanged := false
 	tagsChanged := false
@@ -6375,10 +6376,26 @@ func diffWorkflows(oldWorkflow Workflow, parentWorkflow Workflow, update bool) {
 		}
 	}
 
+	oldWorkflowEnvs, err := GetEnvironments(ctx, oldWorkflow.OrgId)
+	if err != nil {
+		log.Printf("[ERROR][%s] Failed to get distributed workflow environments: %s", oldWorkflow.OrgId, err)
+	}
+
+	// Check if environment is even distributed or not
+	// if not do we need to change the env?
 	for _, action := range oldWorkflow.Actions {
-		if action.Environment != parentWorkflowEnvironment {
+		if strings.ToLower(parentWorkflowEnvironment) == "cloud" {
 			discoveredEnvironment = parentWorkflowEnvironment
 			break
+		}
+
+		for _, env := range oldWorkflowEnvs {
+			if strings.ToLower(parentWorkflowEnvironment) != "cloud" && parentWorkflowEnvironment == env.Name && action.Environment != parentWorkflowEnvironment {
+				discoveredEnvironment = parentWorkflowEnvironment
+				break
+			} else {
+				discoveredEnvironment = action.Environment
+			}
 		}
 	}
 
@@ -6714,7 +6731,6 @@ func diffWorkflows(oldWorkflow Workflow, parentWorkflow Workflow, update bool) {
 	//log.Printf("\n ===== Parent: %#v, Child: %#v =====\n Changes: c | d | m\n Action:  %d | %d | %d\n Trigger: %d | %d | %d\n Branch:  %d | %d | %d", parentWorkflow.ID, oldWorkflow.ID, len(addedActions), len(removedActions), len(updatedActions), len(addedTriggers), len(removedTriggers), len(updatedTriggers), len(addedBranches), len(removedBranches), len(updatedBranches))
 
 	// Use previous rev
-	ctx := context.Background()
 	lastParentRevision := Workflow{}
 	parentRevisions, err := ListWorkflowRevisions(ctx, parentWorkflow.ID, 2)
 	if err != nil {


### PR DESCRIPTION
If the parent workflow changes its environment to something that is not distributed, we don't want to update the distributed workflow, as this would result in the distributed workflow incorrectly having 'cloud' as its environment.