### PR TITLE
Remove org cache from org region before redirecting request

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -11264,6 +11264,9 @@ func HandleCreateSubOrg(resp http.ResponseWriter, request *http.Request) {
 		DeleteCache(ctx, fmt.Sprintf("%s_childorgs", inneruser.ActiveOrg.Id))
 	}
 
+	// Delete parent org cache as well from the org region
+	DeleteCache(ctx, fmt.Sprintf("Organizations_%s", parentOrg.Id))
+
 	// Checking if it's a special region. All user-specific requests should
 	// go through shuffler.io and not subdomains
 	if project.Environment == "cloud" {


### PR DESCRIPTION
Small fix to delete the org cache from org region before redirecting request to main region, so those request going through org region can access newly created suborg org. 