### PR TITLE
Fix: Long SSO certificates not being added due to indexed string size limit

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -2984,6 +2984,8 @@ type FileResponse struct {
 type SSOConfig struct {
 	SSOEntrypoint       string `json:"sso_entrypoint" datastore:"sso_entrypoint"`
 	SSOCertificate      string `json:"sso_certificate" datastore:"sso_certificate"`
+	SSOLongCertificate string `json:"sso_long_certificate" datastore:"sso_long_certificate,noindex"`
+    SSOCertificateHash  string `json:"sso_certificate_hash" datastore:"sso_certificate_hash"`	
 	OpenIdClientId      string `json:"client_id" datastore:"client_id"`
 	OpenIdClientSecret  string `json:"client_secret" datastore:"client_secret"`
 	OpenIdAuthorization string `json:"openid_authorization" datastore:"openid_authorization"`


### PR DESCRIPTION
- The issue was that some SSO certificates were too large and couldn’t be stored the db in the indexed field (`SSOCertificate`).
- I didn’t want to make the existing `SSOCertificate` non-indexed, because we still rely on it for lookups of short certs.
- Also couldn’t switch everything to just a hash, since older orgs don’t have one and that would break backward compatibility.
- So the approach I took was:
  - Keep short certs in the existing `SSOCertificate` field (indexed, works as before).
  - For long certs, store them in a new field `SSOLongCertificate` (noindex), and also keep a hash in `SSOCertificateHash` for lookups.
- On save:
  - If the cert is short → store it as usual.
  - If it’s long → move it to `SSOLongCertificate`, save the hash, and clear the indexed field.
- On read:
  - First try to find a match with the short cert.
  - If that fails, fall back to the hash and check against the long cert.
- This way, old orgs continue to work exactly as before, while new/long certs are supported without breaking anything.

Here’s the frontend [PR](https://github.com/Shuffle/shaffuru/pull/656) for it.