### PR TITLE
fix: decrypt session before setting cookies in auth flows

### DIFF
--- a/db-connector.go
+++ b/db-connector.go
@@ -9845,7 +9845,6 @@ func GetSessionNew(ctx context.Context, sessionId string) (User, error) {
 		}
 
 	} else {
-		// Datastore: try encrypted first, then plain (no IN filter support)
 		for _, sess := range sessionsToSearch {
 			q := datastore.NewQuery(nameKey).Filter("session =", sess).Limit(1)
 			_, err := project.Dbclient.GetAll(ctx, q, &users)


### PR DESCRIPTION
this was stupid on my part. i never tested login itself, i was too concerned about existing users not getting locked out. testing properly this time (the attached session is an invalid one)

<img width="887" height="227" alt="Screenshot 2026-01-15 at 6 35 02 PM" src="https://github.com/user-attachments/assets/d9b48c8b-25f1-47bd-b7fa-fcd30766bb3b" />

Checklist to test for myself:
- [x] Login request
- [x] Registration flow
- [x] SSO flows
- [x] Existing logged in user flow
- [x] Make sure that GetUser and HandleApiAuthentication returns unencrypted user API and session tokens