### PR TITLE
Lot's of agent stuff again

### DIFF
--- a/ai.go
+++ b/ai.go
@@ -7104,7 +7104,7 @@ func abortAgentExecution(ctx context.Context, execution WorkflowExecution, start
 	// log.Printf("[ERROR][%s] AI_AGENT_ABORT: org=%s label=%s decisions=%d llm_calls=%d total_tokens=%d reason=%q", execution.ExecutionId, execution.Workflow.OrgId, abortLabel, len(agentOutput.Decisions), agentOutput.LLMCallCount, agentOutput.TotalTokens, reason)
 
 	abortResult := ActionResult{
-		Status:      "ABORTED",
+		Status:      "SUCCESS",
 		Result:      string(marshalledOutput),
 		Action:      startNode,
 		StartedAt:   time.Now().UnixMilli(),
@@ -7125,10 +7125,7 @@ func abortAgentExecution(ctx context.Context, execution WorkflowExecution, start
 		execution.Results = append(execution.Results, abortResult)
 	}
 
-	execution.Status = "ABORTED"
-
-	go sendAgentActionSelfRequest("ABORTED", execution, abortResult)
-	go SetWorkflowExecution(ctx, execution, true)
+	go sendAgentActionSelfRequest("SUCCESS", execution, abortResult)
 
 	return startNode, errors.New(reason)
 }

--- a/ai.go
+++ b/ai.go
@@ -7054,7 +7054,7 @@ func runSupportRequest(ctx context.Context, input QueryInput) string {
 // Callers must return immediately after this call.
 func abortAgentExecution(ctx context.Context, execution WorkflowExecution, startNode Action, base AgentOutput, abortLabel, reason string) (Action, error) {
 	agentOutput := base
-	agentOutput.Status = "FINISHED"
+	agentOutput.Status = "ABORTED"
 	agentOutput.Error = reason
 	agentOutput.CompletedAt = time.Now().Unix()
 
@@ -7098,19 +7098,13 @@ func abortAgentExecution(ctx context.Context, execution WorkflowExecution, start
 	marshalledOutput, marshalErr := json.Marshal(agentOutput)
 	if marshalErr != nil {
 		log.Printf("[ERROR][%s] abortAgentExecution: failed marshalling AgentOutput: %s", execution.ExecutionId, marshalErr)
-		marshalledOutput = []byte(`{"status":"FINISHED","error":"marshal error"}`)
+		marshalledOutput = []byte(`{"status":"ABORTED","error":"marshal error"}`)
 	}
 
-	log.Printf("[ERROR][%s] AI_AGENT_ABORT: org=%s label=%s decisions=%d llm_calls=%d total_tokens=%d reason=%q", execution.ExecutionId, execution.Workflow.OrgId, abortLabel, len(agentOutput.Decisions), agentOutput.LLMCallCount, agentOutput.TotalTokens, reason)
-
-	abortDuration := int64(0)
-	if agentOutput.StartedAt > 0 && agentOutput.CompletedAt > agentOutput.StartedAt {
-		abortDuration = agentOutput.CompletedAt - agentOutput.StartedAt
-	}
-	log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=%ds decisions=%d llm_calls=%d tokens_used=%d reason=%q", execution.ExecutionId, execution.Workflow.OrgId, abortDuration, len(agentOutput.Decisions), agentOutput.LLMCallCount, agentOutput.TotalTokens, reason)
+	// log.Printf("[ERROR][%s] AI_AGENT_ABORT: org=%s label=%s decisions=%d llm_calls=%d total_tokens=%d reason=%q", execution.ExecutionId, execution.Workflow.OrgId, abortLabel, len(agentOutput.Decisions), agentOutput.LLMCallCount, agentOutput.TotalTokens, reason)
 
 	abortResult := ActionResult{
-		Status:      "SUCCESS",
+		Status:      "ABORTED",
 		Result:      string(marshalledOutput),
 		Action:      startNode,
 		StartedAt:   time.Now().UnixMilli(),
@@ -7131,8 +7125,11 @@ func abortAgentExecution(ctx context.Context, execution WorkflowExecution, start
 		execution.Results = append(execution.Results, abortResult)
 	}
 
-	execution.Status = "FINISHED"
+	execution.Status = "ABORTED"
+
+	go sendAgentActionSelfRequest("ABORTED", execution, abortResult)
 	go SetWorkflowExecution(ctx, execution, true)
+
 	return startNode, errors.New(reason)
 }
 
@@ -7231,16 +7228,7 @@ func HandleAiAgentExecutionStart(execution WorkflowExecution, startNode Action, 
 			err := errors.New("AI Configuration Error: AI_MODEL or OPENAI_MODEL environment variable must be set for On-Premise AI Agent execution.")
 			log.Printf("[ERROR] %v", err)
 
-			execution.Status = "ABORTED"
-			execution.Results = append(execution.Results, ActionResult{
-				Status: "ABORTED",
-				Result: fmt.Sprintf(`{"success": false, "reason": "%s"}`, err.Error()),
-				Action: startNode,
-			})
-
-			go SetWorkflowExecution(ctx, execution, true)
-			log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "missing_onprem_ai_config")
-			return startNode, err
+			return abortAgentExecution(ctx, execution, startNode, AgentOutput{}, "missing_onprem_ai_config", err.Error())
 		}
 	}
 
@@ -7450,8 +7438,7 @@ func HandleAiAgentExecutionStart(execution WorkflowExecution, startNode Action, 
 				relevantDecisions = append(relevantDecisions, mappedResult.Decisions[i])
 			}
 
-			log.Printf("[INFO][%s] AI_AGENT: org=%s decisions_total=%d failures=%d successes=%d last_index=%d",
-				execution.ExecutionId, execution.Workflow.OrgId, len(mappedResult.Decisions), failureCount, successCount, lastFinishedIndex)
+			log.Printf("[INFO][%s] AI_AGENT: org=%s decisions_total=%d failures=%d successes=%d last_index=%d", execution.ExecutionId, execution.Workflow.OrgId, len(mappedResult.Decisions), failureCount, successCount, lastFinishedIndex)
 
 			marshalledDecisions, err = json.Marshal(relevantDecisions)
 			if err != nil {
@@ -7835,15 +7822,7 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 
 	if len(userMessage) == 0 {
 		log.Printf("[ERROR][%s] AI Agent: No user message/input found for action %s", execution.ExecutionId, startNode.ID)
-		execution.Results = append(execution.Results, ActionResult{
-			Status: "ABORTED",
-			Result: fmt.Sprintf(`{"success": false, "reason": "Failed to start AI Agent (3): No input provided."}`),
-			Action: startNode,
-		})
-		go SetWorkflowExecution(ctx, execution, true)
-		log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "no_user_message")
-		return startNode, errors.New("No user message/input found for AI Agent start")
-
+		return abortAgentExecution(ctx, execution, startNode, AgentOutput{}, "no_user_message", "No user message/input found for AI Agent start")
 	}
 
 	// Track who initiated this agent (for audit trail)
@@ -7954,32 +7933,14 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 
 	if err != nil {
 		log.Printf("[ERROR][%s] AI Agent: Failed marshalling input for action %s: %s", execution.ExecutionId, startNode.ID, err)
-
-		execution.Status = "ABORTED"
-		execution.Results = append(execution.Results, ActionResult{
-			Status: "ABORTED",
-			Result: fmt.Sprintf(`{"success": false, "reason": "Failed to start AI Agent (4): %s"}`, strings.Replace(err.Error(), `"`, `\"`, -1)),
-			Action: startNode,
-		})
-		go SetWorkflowExecution(ctx, execution, true)
-		log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "marshal_request_body_failed")
-		return startNode, err
+		return abortAgentExecution(ctx, execution, startNode, AgentOutput{}, "marshal_request_body_failed", fmt.Sprintf("Failed to start AI Agent (4): %s", err.Error()))
 	}
 
 	//go executeSpecificCloudApp(ctx, execution.ExecutionId, execution.Authorization, urls, startNode)
 	if !runOpenaiRequest {
-
+		
 		log.Printf("[ERROR] AI Agent: Unhandled Singul BODY for OpenAI agent (first request): %s. AI APPNAME (can't be empty): %#v", string(initialAgentRequestBody), appname)
-
-		execution.Status = "ABORTED"
-		execution.Results = append(execution.Results, ActionResult{
-			Status: "ABORTED",
-			Result: fmt.Sprintf(`{"success": false, "reason": "Failed to start AI Agent (5): Failed initial AI request. Contact support@shuffler.io if this persists."}`),
-			Action: startNode,
-		})
-		go SetWorkflowExecution(ctx, execution, true)
-		log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "unsupported_app_not_openai")
-		return startNode, errors.New("Unhandled Singul BODY for OpenAI agent (first request)")
+		return abortAgentExecution(ctx, execution, startNode, AgentOutput{}, "unsupported_app_not_openai", "Failed to start AI Agent (5): Failed initial AI request. Contact support@shuffler.io if this persists.")
 	}
 
 	if debug {
@@ -8027,16 +7988,7 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 	marshalledAction, err := json.Marshal(aiNode)
 	if err != nil {
 		log.Printf("[ERROR][%s] AI Agent: Failed marshalling action for AI Agent (first agent request): %s", execution.ExecutionId, err)
-
-		execution.Status = "ABORTED"
-		execution.Results = append(execution.Results, ActionResult{
-			Status: "ABORTED",
-			Result: fmt.Sprintf(`{"success": false, "reason": "Failed to start AI Agent (6): %s"}`, strings.Replace(err.Error(), `"`, `\"`, -1)),
-			Action: startNode,
-		})
-		go SetWorkflowExecution(ctx, execution, true)
-		log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "marshal_ai_action_failed")
-		return startNode, err
+		return abortAgentExecution(ctx, execution, startNode, AgentOutput{}, "marshal_ai_action_failed", fmt.Sprintf("Failed to start AI Agent (6): %s", err.Error()))
 	}
 
 	// Self-request starts here!
@@ -8088,7 +8040,7 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 	)
 
 	if err != nil {
-		log.Printf("[ERROR][%s] AI Agent: Failed creating request during LLM setup: %s", execution.ExecutionId, err)
+		log.Printf("[ERROR][%s] AI_AGENT_LLM_FAILURE: Failed creating request during LLM setup: %s", execution.ExecutionId, err)
 		return abortAgentExecution(ctx, execution, startNode, oldAgentOutput, "llm_request_build_failed", fmt.Sprintf("Failed to start AI Agent (7): %s", err.Error()))
 	}
 
@@ -8177,17 +8129,8 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 		outputMap := HTTPOutput{}
 		err = json.Unmarshal([]byte(resultMapping.Result), &outputMap)
 		if err != nil {
-			log.Printf("[ERROR][%s] AI Agent (3): Failed unmarshalling response from sending request for stream during SKIPPED user input: %s. Body: %s", execution.ExecutionId, err, string(resultMapping.Result))
-
-			execution.Status = "ABORTED"
-			execution.Results = append(execution.Results, ActionResult{
-				Status: "ABORTED",
-				Result: fmt.Sprintf(`{"success": false, "reason": "Failed to start AI Agent (1): %s"}`, strings.Replace(err.Error(), `"`, `\"`, -1)),
-				Action: startNode,
-			})
-			go SetWorkflowExecution(ctx, execution, true)
-			log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "llm_response_unmarshal_failed")
-			return startNode, err
+			log.Printf("[ERROR][%s] AI Agent: Failed unmarshalling response from sending request for stream during SKIPPED user input: %s. Body: %s", execution.ExecutionId, err, string(resultMapping.Result))
+			return abortAgentExecution(ctx, execution, startNode, AgentOutput{}, "llm_response_unmarshal_failed", fmt.Sprintf("Failed to start AI Agent (1): %s", err.Error()))
 		}
 
 		if outputMap.Status != 200 {
@@ -8212,16 +8155,7 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 			bodyString, err = json.Marshal(bodyMap)
 			if err != nil {
 				log.Printf("[ERROR] AI Agent: Failed marshalling body to string in AI Agent response: %s", err)
-
-				execution.Status = "ABORTED"
-				execution.Results = append(execution.Results, ActionResult{
-					Status: "ABORTED",
-					Result: fmt.Sprintf(`{"success": false, "reason": "Failed to start AI Agent (3): %s"}`, strings.Replace(err.Error(), `"`, `\"`, -1)),
-					Action: startNode,
-				})
-				go SetWorkflowExecution(ctx, execution, true)
-				log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "llm_body_marshal_failed")
-				return startNode, err
+				return abortAgentExecution(ctx, execution, startNode, AgentOutput{}, "llm_body_marshal_failed", fmt.Sprintf("Failed to start AI Agent (3): %s", err.Error()))
 			}
 		}
 
@@ -8244,12 +8178,13 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 			newOutput := openai.ErrorResponse{}
 			err = json.Unmarshal(bodyString, &newOutput)
 			if err == nil && len(newOutput.Error.Message) > 0 {
-				choicesString = fmt.Sprintf("LLM Error: %s", newOutput.Error.Message)
+				// choicesString = fmt.Sprintf("LLM Error: %s", newOutput.Error.Message)
 
-				resultMapping.Status = "FAILURE"
-
-				// Log LLM failure with details
+				// resultMapping.Status = "FAILURE"
+				// LLM returned a proper error (401 invalid key, 429 rate limit, 500 server error, etc.)
+				// Abort 
 				log.Printf("[ERROR][%s] AI_AGENT_LLM_FAILURE: org=%s status_code=%d error_type=%s error_message=%s", execution.ExecutionId, execution.Workflow.OrgId, outputMap.Status, newOutput.Error.Type, newOutput.Error.Message)
+				return abortAgentExecution(ctx, execution, startNode, oldAgentOutput, "llm_http_error", fmt.Sprintf("LLM error (HTTP %d %s): %s", outputMap.Status, newOutput.Error.Type, newOutput.Error.Message))
 			} else {
 				log.Printf("[ERROR][%s] AI Agent: No choices, nor error found in AI agent response. Status: %d. Raw: %s", execution.ExecutionId, outputMap.Status, bodyString)
 				resultMapping.Status = "FAILURE"
@@ -8803,10 +8738,14 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 			}
 
 			if !foundResult {
-				log.Printf("[DEBUG][%s] Result not found in execution.Results, using resultMapping for sendAgentActionSelfRequest", execution.ExecutionId)
-				resultMapping.Status = "SUCCESS"
-				resultMapping.CompletedAt = agentOutput.CompletedAt
-				go sendAgentActionSelfRequest("SUCCESS", execution, resultMapping)
+				// duration := int64(0)
+				// if agentOutput.StartedAt > 0 && agentOutput.CompletedAt > 0 {
+				// 	duration = agentOutput.CompletedAt - agentOutput.StartedAt
+				// } else if agentOutput.StartedAt > 0 {
+				// 	duration = time.Now().Unix() - agentOutput.StartedAt
+				// }
+
+				// log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=SUCCESS duration=%ds decisions=%d llm_calls=%d tokens_used=%d", execution.ExecutionId, execution.Workflow.OrgId, duration, len(agentOutput.Decisions), agentOutput.LLMCallCount, agentOutput.TotalTokens)
 			}
 		}
 
@@ -8848,7 +8787,7 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 			}
 		}
 	}
-  
+
 	if createNextActions {
 		return startNode, nil
 	}
@@ -9033,7 +8972,6 @@ func GenerateSingulWorkflows(resp http.ResponseWriter, request *http.Request) {
 		resp.Write([]byte(`{"success": false, "reason": "No workflow found for this ID"}`))
 		return
 	}
-
 
 	// Maps everything AROUND the usecase
 	err = HandleSingulWorkflowEnablement(ctx, *workflow, user, categoryAction)

--- a/ai.go
+++ b/ai.go
@@ -7836,13 +7836,11 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 
 	if !createNextActions {
 		caller, _ := ctx.Value("caller").(string)
-    	traceID, _ := ctx.Value("trace_id").(string)
 		if strings.TrimSpace(caller) == "" {
-			log.Printf("ERROR[%s] AI agent: No caller function info provided for AI agent, aborting the request ...", execution.ExecutionId)
-			return abortAgentExecution(ctx, execution, startNode, AgentOutput{}, "no_caller_info", "No caller function info provided for AI Agent start")
+			caller = "unknown"
 		}
 
-		log.Printf("[INFO][%s] AI_AGENT_START: org=%s workflow=%s user=%s caller=%s trace-id=%s input_length=%d", execution.ExecutionId, execution.Workflow.OrgId, execution.WorkflowId, initiatedBy, caller, traceID, len(userMessage))
+		log.Printf("[INFO][%s] AI_AGENT_START: org=%s workflow=%s user=%s caller=%s input_length=%d", execution.ExecutionId, execution.Workflow.OrgId, execution.WorkflowId, initiatedBy, caller, len(userMessage))
 	}
 
 	// Set model based on environment

--- a/ai.go
+++ b/ai.go
@@ -7663,6 +7663,11 @@ func HandleAiAgentExecutionStart(execution WorkflowExecution, startNode Action, 
 
 						decidedApps += lowername + ", "
 					}
+
+					//  Let's inject http.
+					if !strings.Contains(decidedApps, "http") {
+						decidedApps += "http, "
+					}
 				}
 
 				if len(decidedApps) > 0 {
@@ -8779,6 +8784,10 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 				log.Printf("[ERROR][%s] AI Agent: Failed updating AI requests: %s", execution.ExecutionId, err)
 			}
 		}
+	}
+  
+	if createNextActions {
+		return startNode, nil
 	}
 
 	// 1. Map the response back

--- a/ai.go
+++ b/ai.go
@@ -7180,8 +7180,7 @@ func sendAITokenLimitAlert(ctx context.Context, execution WorkflowExecution, ful
 // createNextActions = false => start of agent to find initial decisions
 // createNextActions = true => mid-agent to decide next steps
 func HandleAiAgentExecutionStart(execution WorkflowExecution, startNode Action, createNextActions bool, callerName string) (Action, error) {
-
-	aiStarttime := time.Now().Unix()
+	aiStarttime := time.Now().UnixMilli()
 	// A handler to ensure we ALWAYS focus on next actions if a node starts late
 	// or is missing context, but has previous decisions
 	for _, result := range execution.Results {

--- a/ai.go
+++ b/ai.go
@@ -8733,7 +8733,7 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 
 		//log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s status=%s duration=%ds decisions=%d", execution.ExecutionId, agentOutput.Status, time.Now().Unix()-agentOutput.StartedAt, len(agentOutput.Decisions))
 
-		if agentOutput.Status == "FINISHED" && agentOutput.CompletedAt > 0 && execution.Status == "EXECUTING" {
+		if agentOutput.Status == "FINISHED" && agentOutput.CompletedAt > 0 && execution.Status != "ABORTED" && execution.Status != "FAILURE" {
 			duration := agentOutput.CompletedAt - agentOutput.StartedAt
 			log.Printf("[INFO][%s] AI_AGENT_COMPLETE: org=%s duration=%ds decisions=%d llm_calls=%d total_tokens=%d status=SUCCESS", execution.ExecutionId, execution.Workflow.OrgId, duration, len(agentOutput.Decisions), agentOutput.LLMCallCount, agentOutput.TotalTokens)
 			for resultIndex, result := range execution.Results {

--- a/ai.go
+++ b/ai.go
@@ -8182,7 +8182,6 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 
 				// resultMapping.Status = "FAILURE"
 				// LLM returned a proper error (401 invalid key, 429 rate limit, 500 server error, etc.)
-				// Abort 
 				log.Printf("[ERROR][%s] AI_AGENT_LLM_FAILURE: org=%s status_code=%d error_type=%s error_message=%s", execution.ExecutionId, execution.Workflow.OrgId, outputMap.Status, newOutput.Error.Type, newOutput.Error.Message)
 				return abortAgentExecution(ctx, execution, startNode, oldAgentOutput, "llm_http_error", fmt.Sprintf("LLM error (HTTP %d %s): %s", outputMap.Status, newOutput.Error.Type, newOutput.Error.Message))
 			} else {

--- a/ai.go
+++ b/ai.go
@@ -7182,7 +7182,8 @@ func sendAITokenLimitAlert(ctx context.Context, execution WorkflowExecution, ful
 
 // createNextActions = false => start of agent to find initial decisions
 // createNextActions = true => mid-agent to decide next steps
-func HandleAiAgentExecutionStart(execution WorkflowExecution, startNode Action, createNextActions bool) (Action, error) {
+func HandleAiAgentExecutionStart(execution WorkflowExecution, startNode Action, createNextActions bool, caller string, traceID string) (Action, error) {
+
 	aiStarttime := time.Now().Unix()
 	// A handler to ensure we ALWAYS focus on next actions if a node starts late
 	// or is missing context, but has previous decisions
@@ -7832,7 +7833,12 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 	}
 
 	if !createNextActions {
-		log.Printf("[INFO] AI_AGENT_START: execution_id=%s org=%s user=%s input_length=%d", execution.ExecutionId, execution.Workflow.OrgId, initiatedBy, len(userMessage))
+		if strings.TrimSpace(caller) == "" {
+			log.Printf("ERROR[%s] AI agent: No caller function info provided for AI agent, aborting the request ...", execution.ExecutionId)
+			return abortAgentExecution(ctx, execution, startNode, AgentOutput{}, "no_caller_info", "No caller function info provided for AI Agent start")
+		}
+
+		log.Printf("[INFO][%s] AI_AGENT_START: org=%s workflow=%s user=%s caller=%s trace-id=%s input_length=%d", execution.ExecutionId, execution.Workflow.OrgId, execution.WorkflowId, initiatedBy, caller, traceID, len(userMessage))
 	}
 
 	// Set model based on environment
@@ -13144,7 +13150,7 @@ func RunMCPAction(resp http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	workflowExecution, err := PrepareSingleAction(ctx, request, user, "agent", marshalledAction, false, "")
+	workflowExecution, err := PrepareSingleAction(ctx, request, user, "agent", marshalledAction, false, "RunMCPAction", "",  "")
 	if fileId == "agent_starter" {
 		log.Printf("[INFO] Returning early for agent_starter single action execution: %s", workflowExecution.ExecutionId)
 		resp.WriteHeader(200)

--- a/ai.go
+++ b/ai.go
@@ -7101,9 +7101,13 @@ func abortAgentExecution(ctx context.Context, execution WorkflowExecution, start
 		marshalledOutput = []byte(`{"status":"FINISHED","error":"marshal error"}`)
 	}
 
-	log.Printf("[ERROR][%s] AI_AGENT_ABORT: org=%s label=%s decisions=%d llm_calls=%d total_tokens=%d reason=%q",
-		execution.ExecutionId, execution.Workflow.OrgId, abortLabel,
-		len(agentOutput.Decisions), agentOutput.LLMCallCount, agentOutput.TotalTokens, reason)
+	log.Printf("[ERROR][%s] AI_AGENT_ABORT: org=%s label=%s decisions=%d llm_calls=%d total_tokens=%d reason=%q", execution.ExecutionId, execution.Workflow.OrgId, abortLabel, len(agentOutput.Decisions), agentOutput.LLMCallCount, agentOutput.TotalTokens, reason)
+
+	abortDuration := int64(0)
+	if agentOutput.StartedAt > 0 && agentOutput.CompletedAt > agentOutput.StartedAt {
+		abortDuration = agentOutput.CompletedAt - agentOutput.StartedAt
+	}
+	log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=%ds decisions=%d llm_calls=%d tokens_used=%d reason=%q", execution.ExecutionId, execution.Workflow.OrgId, abortDuration, len(agentOutput.Decisions), agentOutput.LLMCallCount, agentOutput.TotalTokens, reason)
 
 	abortResult := ActionResult{
 		Status:      "SUCCESS",
@@ -7235,6 +7239,7 @@ func HandleAiAgentExecutionStart(execution WorkflowExecution, startNode Action, 
 			})
 
 			go SetWorkflowExecution(ctx, execution, true)
+			log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "missing_onprem_ai_config")
 			return startNode, err
 		}
 	}
@@ -7836,7 +7841,7 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 			Action: startNode,
 		})
 		go SetWorkflowExecution(ctx, execution, true)
-
+		log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "no_user_message")
 		return startNode, errors.New("No user message/input found for AI Agent start")
 
 	}
@@ -7957,7 +7962,7 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 			Action: startNode,
 		})
 		go SetWorkflowExecution(ctx, execution, true)
-
+		log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "marshal_request_body_failed")
 		return startNode, err
 	}
 
@@ -7973,7 +7978,7 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 			Action: startNode,
 		})
 		go SetWorkflowExecution(ctx, execution, true)
-
+		log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "unsupported_app_not_openai")
 		return startNode, errors.New("Unhandled Singul BODY for OpenAI agent (first request)")
 	}
 
@@ -8030,7 +8035,7 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 			Action: startNode,
 		})
 		go SetWorkflowExecution(ctx, execution, true)
-
+		log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "marshal_ai_action_failed")
 		return startNode, err
 	}
 
@@ -8181,12 +8186,13 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 				Action: startNode,
 			})
 			go SetWorkflowExecution(ctx, execution, true)
-
+			log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "llm_response_unmarshal_failed")
 			return startNode, err
 		}
 
 		if outputMap.Status != 200 {
 			log.Printf("[ERROR][%s] AI Agent: Failed to run AI agent with status code %d", execution.ExecutionId, outputMap.Status)
+			// Don't log AI_AGENT_LLM_FAILURE here yet - wait to see if we can parse the error details below
 			//return startNode, errors.New(fmt.Sprintf("Failed to run AI agent with status code %d", outputMap.Status))
 		}
 
@@ -8199,6 +8205,9 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 
 			//choicesString = fmt.Sprintf("LLM Response Error: %s", string(resultMapping.Result))
 			choicesString = fmt.Sprintf("%s", string(resultMapping.Result))
+
+			// Log LLM failure for body parsing error
+			log.Printf("[ERROR][%s] AI_AGENT_LLM_FAILURE: org=%s status_code=%d error_type=body_parse_error raw_response=%s", execution.ExecutionId, execution.Workflow.OrgId, outputMap.Status, string(resultMapping.Result))
 		} else {
 			bodyString, err = json.Marshal(bodyMap)
 			if err != nil {
@@ -8211,7 +8220,7 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 					Action: startNode,
 				})
 				go SetWorkflowExecution(ctx, execution, true)
-
+				log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s org=%s status=ABORTED duration=0s decisions=0 llm_calls=0 tokens_used=0 reason=%q", execution.ExecutionId, execution.Workflow.OrgId, "llm_body_marshal_failed")
 				return startNode, err
 			}
 		}
@@ -8238,9 +8247,15 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 				choicesString = fmt.Sprintf("LLM Error: %s", newOutput.Error.Message)
 
 				resultMapping.Status = "FAILURE"
+
+				// Log LLM failure with details
+				log.Printf("[ERROR][%s] AI_AGENT_LLM_FAILURE: org=%s status_code=%d error_type=%s error_message=%s", execution.ExecutionId, execution.Workflow.OrgId, outputMap.Status, newOutput.Error.Type, newOutput.Error.Message)
 			} else {
 				log.Printf("[ERROR][%s] AI Agent: No choices, nor error found in AI agent response. Status: %d. Raw: %s", execution.ExecutionId, outputMap.Status, bodyString)
 				resultMapping.Status = "FAILURE"
+
+				// Log LLM failure for unknown error format
+				log.Printf("[ERROR][%s] AI_AGENT_LLM_FAILURE: org=%s status_code=%d error_type=unknown_format raw_response=%s", execution.ExecutionId, execution.Workflow.OrgId, outputMap.Status, string(bodyString))
 			}
 		} else {
 			choicesString = openaiOutput.Choices[0].Message.Content
@@ -8691,6 +8706,44 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 
 		if !decisionActionRan && !strings.Contains(decisionString, conditionText) {
 			log.Printf("[ERROR][%s] AI Agent: No decision action was run. Marking the agent as FAILURE.", execution.ExecutionId)
+
+			// Properly mark the agent as failed
+			agentOutput.Status = "FAILURE"
+			agentOutput.CompletedAt = time.Now().Unix()
+
+			sentFailure := false
+			// Update the result status - finds the existing node entry in execution.Results
+			for resultIndex, result := range execution.Results {
+				if result.Action.ID != startNode.ID {
+					continue
+				}
+
+				execution.Results[resultIndex].Status = "FAILURE"
+				execution.Results[resultIndex].CompletedAt = agentOutput.CompletedAt
+
+				marshalledAgentOutput, err := json.Marshal(agentOutput)
+				if err != nil {
+					log.Printf("[ERROR] AI Agent: Failed marshalling agent output for FAILURE: %s", err)
+				} else {
+					execution.Results[resultIndex].Result = string(marshalledAgentOutput)
+					resultMapping.Result = string(marshalledAgentOutput)
+				}
+
+				log.Printf("[DEBUG][%s] About to call sendAgentActionSelfRequest for FAILURE on agent action %s", execution.ExecutionId, startNode.ID)
+				go sendAgentActionSelfRequest("FAILURE", execution, execution.Results[resultIndex])
+				sentFailure = true
+				break
+			}
+
+			if !sentFailure {
+				log.Printf("[WARNING][%s] AI Agent: No result entry found in execution.Results, using resultMapping fallback", execution.ExecutionId)
+				fallbackOutput, merr := json.Marshal(agentOutput)
+				if merr == nil {
+					resultMapping.Status = "FAILURE"
+					resultMapping.Result = string(fallbackOutput)
+				}
+				go sendAgentActionSelfRequest("FAILURE", execution, resultMapping)
+			}
 		}
 
 		marshalledAgentOutput, err := json.Marshal(agentOutput)
@@ -8734,8 +8787,8 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 		//log.Printf("[INFO] AI_AGENT_FINISH: execution_id=%s status=%s duration=%ds decisions=%d", execution.ExecutionId, agentOutput.Status, time.Now().Unix()-agentOutput.StartedAt, len(agentOutput.Decisions))
 
 		if agentOutput.Status == "FINISHED" && agentOutput.CompletedAt > 0 && execution.Status != "ABORTED" && execution.Status != "FAILURE" {
-			duration := agentOutput.CompletedAt - agentOutput.StartedAt
-			log.Printf("[INFO][%s] AI_AGENT_COMPLETE: org=%s duration=%ds decisions=%d llm_calls=%d total_tokens=%d status=SUCCESS", execution.ExecutionId, execution.Workflow.OrgId, duration, len(agentOutput.Decisions), agentOutput.LLMCallCount, agentOutput.TotalTokens)
+
+			foundResult := false
 			for resultIndex, result := range execution.Results {
 				if result.Action.ID != startNode.ID {
 					continue
@@ -8745,12 +8798,22 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 				execution.Results[resultIndex].CompletedAt = agentOutput.CompletedAt
 				log.Printf("[DEBUG][%s] About to call sendAgentActionSelfRequest for agent action %s", execution.ExecutionId, startNode.ID)
 				go sendAgentActionSelfRequest("SUCCESS", execution, execution.Results[resultIndex])
+				foundResult = true
 				break
+			}
+
+			if !foundResult {
+				log.Printf("[DEBUG][%s] Result not found in execution.Results, using resultMapping for sendAgentActionSelfRequest", execution.ExecutionId)
+				resultMapping.Status = "SUCCESS"
+				resultMapping.CompletedAt = agentOutput.CompletedAt
+				go sendAgentActionSelfRequest("SUCCESS", execution, resultMapping)
 			}
 		}
 
 	} else {
-		log.Printf("[ERROR] AI Agent: No result found in AI agent response. Status: %d. Body: %s", newresp.StatusCode, string(body))
+		// LLM returned an empty result body — this is a failure
+		log.Printf("[ERROR][%s] AI_AGENT_LLM_FAILURE: Empty result body from LLM response (status %d). Aborting agent.", execution.ExecutionId, newresp.StatusCode)
+		return abortAgentExecution(ctx, execution, startNode, oldAgentOutput, "empty_llm_result", fmt.Sprintf("LLM returned empty response body with HTTP status %d", newresp.StatusCode))
 	}
 
 	if memorizationEngine == "shuffle_db" {

--- a/ai.go
+++ b/ai.go
@@ -8553,11 +8553,14 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 						question = mappedDecision.Fields[0].Value
 					}
 
+					// Escape single quotes to prevent quote injection
+					safeQuestion := strings.ReplaceAll(question, "'", "\\'")
+
 					err = CreateOrgNotification(
 						ctx,
-						fmt.Sprintf("Agent - input required: '%s'", question),
-						fmt.Sprintf("Input required during agent run."), 
-						fmt.Sprintf("/forms/%s?authorization=%s&reference_execution=%s&source_node=%s&decision_id=%s&backend_url=%s", execution.WorkflowId, execution.Authorization, execution.ExecutionId, startNode.ID, mappedDecision.RunDetails.Id, backendUrl),
+						fmt.Sprintf("Agent - input required: '%s'", safeQuestion),
+						fmt.Sprintf("Input required during agent run."),
+						fmt.Sprintf("/forms/%s?authorization=%s&reference_execution=%s&source_node=%s&decision_id=%s&backend_url=%s", execution.WorkflowId, url.QueryEscape(execution.Authorization), execution.ExecutionId, startNode.ID, mappedDecision.RunDetails.Id, url.QueryEscape(backendUrl)),
 						execution.ExecutionOrg,
 						false,
 						"LOW",

--- a/ai.go
+++ b/ai.go
@@ -13154,7 +13154,7 @@ func RunMCPAction(resp http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	workflowExecution, err := PrepareSingleAction(ctx, request, user, "agent", marshalledAction, false, "RunMCPAction", "",  "")
+	workflowExecution, err := PrepareSingleAction(ctx, request, user, "agent", marshalledAction, false, "")
 	if fileId == "agent_starter" {
 		log.Printf("[INFO] Returning early for agent_starter single action execution: %s", workflowExecution.ExecutionId)
 		resp.WriteHeader(200)

--- a/ai.go
+++ b/ai.go
@@ -7182,7 +7182,7 @@ func sendAITokenLimitAlert(ctx context.Context, execution WorkflowExecution, ful
 
 // createNextActions = false => start of agent to find initial decisions
 // createNextActions = true => mid-agent to decide next steps
-func HandleAiAgentExecutionStart(execution WorkflowExecution, startNode Action, createNextActions bool, caller string, traceID string) (Action, error) {
+func HandleAiAgentExecutionStart(ctx context.Context, execution WorkflowExecution, startNode Action, createNextActions bool) (Action, error) {
 
 	aiStarttime := time.Now().Unix()
 	// A handler to ensure we ALWAYS focus on next actions if a node starts late
@@ -7221,7 +7221,9 @@ func HandleAiAgentExecutionStart(execution WorkflowExecution, startNode Action, 
 		execution.Workflow.OrgId = execution.ExecutionOrg
 	}
 
-	ctx := context.Background()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	// Validate On-Prem Configuration immediately
 	if project.Environment != "cloud" {
@@ -7833,6 +7835,8 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 	}
 
 	if !createNextActions {
+		caller, _ := ctx.Value("caller").(string)
+    	traceID, _ := ctx.Value("trace_id").(string)
 		if strings.TrimSpace(caller) == "" {
 			log.Printf("ERROR[%s] AI agent: No caller function info provided for AI agent, aborting the request ...", execution.ExecutionId)
 			return abortAgentExecution(ctx, execution, startNode, AgentOutput{}, "no_caller_info", "No caller function info provided for AI Agent start")

--- a/ai.go
+++ b/ai.go
@@ -7182,7 +7182,7 @@ func sendAITokenLimitAlert(ctx context.Context, execution WorkflowExecution, ful
 
 // createNextActions = false => start of agent to find initial decisions
 // createNextActions = true => mid-agent to decide next steps
-func HandleAiAgentExecutionStart(ctx context.Context, execution WorkflowExecution, startNode Action, createNextActions bool) (Action, error) {
+func HandleAiAgentExecutionStart(execution WorkflowExecution, startNode Action, createNextActions bool, callerName string) (Action, error) {
 
 	aiStarttime := time.Now().Unix()
 	// A handler to ensure we ALWAYS focus on next actions if a node starts late
@@ -7221,9 +7221,7 @@ func HandleAiAgentExecutionStart(ctx context.Context, execution WorkflowExecutio
 		execution.Workflow.OrgId = execution.ExecutionOrg
 	}
 
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	ctx := context.Background()
 
 	// Validate On-Prem Configuration immediately
 	if project.Environment != "cloud" {
@@ -7835,12 +7833,11 @@ You are the Action Execution Agent for the Shuffle platform. You receive tools (
 	}
 
 	if !createNextActions {
-		caller, _ := ctx.Value("caller").(string)
-		if strings.TrimSpace(caller) == "" {
-			caller = "unknown"
+		if strings.TrimSpace(callerName) == "" {
+			callerName = "unknown"
 		}
 
-		log.Printf("[INFO][%s] AI_AGENT_START: org=%s workflow=%s user=%s caller=%s input_length=%d", execution.ExecutionId, execution.Workflow.OrgId, execution.WorkflowId, initiatedBy, caller, len(userMessage))
+		log.Printf("[INFO][%s] AI_AGENT_START: org=%s workflow=%s user=%s caller=%s input_length=%d", execution.ExecutionId, execution.Workflow.OrgId, execution.WorkflowId, initiatedBy, callerName, len(userMessage))
 	}
 
 	// Set model based on environment

--- a/ai.go
+++ b/ai.go
@@ -7436,7 +7436,9 @@ func HandleAiAgentExecutionStart(execution WorkflowExecution, startNode Action, 
 				relevantDecisions = append(relevantDecisions, mappedResult.Decisions[i])
 			}
 
-			log.Printf("[INFO][%s] AI_AGENT: org=%s decisions_total=%d failures=%d successes=%d last_index=%d", execution.ExecutionId, execution.Workflow.OrgId, len(mappedResult.Decisions), failureCount, successCount, lastFinishedIndex)
+			if debug {
+				log.Printf("[INFO][%s] AI_AGENT: org=%s decisions_total=%d failures=%d successes=%d last_index=%d", execution.ExecutionId, execution.Workflow.OrgId, len(mappedResult.Decisions), failureCount, successCount, lastFinishedIndex)
+			}
 
 			marshalledDecisions, err = json.Marshal(relevantDecisions)
 			if err != nil {

--- a/codegen.go
+++ b/codegen.go
@@ -4819,11 +4819,6 @@ func handleRunDatastoreAutomation(ctx context.Context, cacheData CacheKeyData, a
 		ctx = context.Background()
 	}
 
-	traceID, _ := ctx.Value("trace_id").(string)
-	if traceID == "" {
-		traceID = fmt.Sprintf("ROOT-%s", uuid.NewV4().String())
-	}
-
 	parsedName := strings.ReplaceAll(strings.ToLower(automation.Name), " ", "_")
 
 	// These are ran pre-execution
@@ -4896,7 +4891,7 @@ func handleRunDatastoreAutomation(ctx context.Context, cacheData CacheKeyData, a
 		// november 2025 after adding graphic system to datastore
 
 	} else if parsedName == "run_ai_agent" {
-		log.Printf("[INFO] AI agent: Handling run_ai_agent automation for key %s in category %s with trace-id %s", cacheData.Key, cacheData.Category, traceID)
+		log.Printf("[INFO] AI agent: Handling run_ai_agent automation for key %s in category %s", cacheData.Key, cacheData.Category)
 		if len(foundApikey) == 0 {
 			log.Printf("[ERROR] No admin user with API key found for org %s", cacheData.OrgId)
 			return errors.New("No admin user with API key found")
@@ -4986,7 +4981,6 @@ func handleRunDatastoreAutomation(ctx context.Context, cacheData CacheKeyData, a
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", foundApikey))
 			req.Header.Set("Org-Id", cacheData.OrgId)
 			req.Header.Set("X-Internal-Caller", "handleRunDatastoreAutomation")
-			req.Header.Set("X-Trace-ID", traceID)
 
 			resp, err := client.Do(req)
 			if err != nil {

--- a/codegen.go
+++ b/codegen.go
@@ -11,6 +11,7 @@ import (
 	"crypto/md5"
 	"crypto/sha256"
 	"encoding/json"
+	"math/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -4806,7 +4807,7 @@ func handleDatastoreAutomationWebhook(ctx context.Context, marshalledBody []byte
 	return nil
 }
 
-func handleRunDatastoreAutomation(cacheData CacheKeyData, automation DatastoreAutomation) error {
+func handleRunDatastoreAutomation(ctx context.Context, cacheData CacheKeyData, automation DatastoreAutomation) error {
 	if len(cacheData.OrgId) == 0 {
 		return errors.New("CacheKeyData.OrgId is required for handleRunAutomation")
 	}
@@ -4814,8 +4815,16 @@ func handleRunDatastoreAutomation(cacheData CacheKeyData, automation DatastoreAu
 	if len(cacheData.Category) == 0 {
 		return errors.New("CacheKeyData.Category is required for handleRunAutomation")
 	}
+    
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
-	ctx := context.Background()
+	traceID, _ := ctx.Value("trace_id").(string)
+	if traceID == "" {
+    	traceID = fmt.Sprintf("ROOT-%d-%d", time.Now().UnixNano(), rand.Intn(1000))
+	}
+
 	parsedName := strings.ReplaceAll(strings.ToLower(automation.Name), " ", "_")
 
 	// These are ran pre-execution
@@ -4888,7 +4897,7 @@ func handleRunDatastoreAutomation(cacheData CacheKeyData, automation DatastoreAu
 		// november 2025 after adding graphic system to datastore
 
 	} else if parsedName == "run_ai_agent" {
-		log.Printf("[DEBUG] Handling run_ai_agent automation for key %s in category %s", cacheData.Key, cacheData.Category)
+		log.Printf("[INFO] Handling run_ai_agent automation for key %s in category %s with trace-id %s", cacheData.Key, cacheData.Category, traceID)
 		if len(foundApikey) == 0 {
 			log.Printf("[ERROR] No admin user with API key found for org %s", cacheData.OrgId)
 			return errors.New("No admin user with API key found")
@@ -4975,8 +4984,10 @@ func handleRunDatastoreAutomation(cacheData CacheKeyData, automation DatastoreAu
 				return err
 			}
 
-			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", foundApikey))
-			req.Header.Add("Org-Id", cacheData.OrgId)
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", foundApikey))
+			req.Header.Set("Org-Id", cacheData.OrgId)
+			req.Header.Set("X-Internal-Caller", "handleRunDatastoreAutomation")
+			req.Header.Set("X-Trace-ID", traceID)
 
 			resp, err := client.Do(req)
 			if err != nil {

--- a/codegen.go
+++ b/codegen.go
@@ -4897,7 +4897,7 @@ func handleRunDatastoreAutomation(ctx context.Context, cacheData CacheKeyData, a
 		// november 2025 after adding graphic system to datastore
 
 	} else if parsedName == "run_ai_agent" {
-		log.Printf("[INFO] Handling run_ai_agent automation for key %s in category %s with trace-id %s", cacheData.Key, cacheData.Category, traceID)
+		log.Printf("[INFO] AI agent: Handling run_ai_agent automation for key %s in category %s with trace-id %s", cacheData.Key, cacheData.Category, traceID)
 		if len(foundApikey) == 0 {
 			log.Printf("[ERROR] No admin user with API key found for org %s", cacheData.OrgId)
 			return errors.New("No admin user with API key found")

--- a/codegen.go
+++ b/codegen.go
@@ -4891,7 +4891,7 @@ func handleRunDatastoreAutomation(ctx context.Context, cacheData CacheKeyData, a
 		// november 2025 after adding graphic system to datastore
 
 	} else if parsedName == "run_ai_agent" {
-		log.Printf("[INFO] AI agent: Handling run_ai_agent automation for key %s in category %s", cacheData.Key, cacheData.Category)
+		log.Printf("[DEBUG] AI agent: Handling run_ai_agent automation for key %s in category %s", cacheData.Key, cacheData.Category)
 		if len(foundApikey) == 0 {
 			log.Printf("[ERROR] No admin user with API key found for org %s", cacheData.OrgId)
 			return errors.New("No admin user with API key found")

--- a/codegen.go
+++ b/codegen.go
@@ -11,7 +11,6 @@ import (
 	"crypto/md5"
 	"crypto/sha256"
 	"encoding/json"
-	"math/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -4822,7 +4821,7 @@ func handleRunDatastoreAutomation(ctx context.Context, cacheData CacheKeyData, a
 
 	traceID, _ := ctx.Value("trace_id").(string)
 	if traceID == "" {
-    	traceID = fmt.Sprintf("ROOT-%d-%d", time.Now().UnixNano(), rand.Intn(1000))
+		traceID = fmt.Sprintf("ROOT-%s", uuid.NewV4().String())
 	}
 
 	parsedName := strings.ReplaceAll(strings.ToLower(automation.Name), " ", "_")

--- a/db-connector.go
+++ b/db-connector.go
@@ -14758,7 +14758,7 @@ func SetDatastoreKeyBulk(ctx context.Context, allKeys []CacheKeyData) ([]Datasto
 					// Run the automation
 					// This should make a notification if it fails
 					go func(cacheData CacheKeyData, automation DatastoreAutomation) {
-						err := handleRunDatastoreAutomation(cacheData, automation)
+						err := handleRunDatastoreAutomation(ctx, cacheData, automation)
 						if err != nil {
 							log.Printf("[ERROR] Failed running automation %s for cache key %s: %s", automation.Name, cacheData.Key, err)
 
@@ -15267,7 +15267,7 @@ func SetDatastoreKey(ctx context.Context, cacheData CacheKeyData) error {
 				// Run the automation
 				// This should make a notification if it fails
 				go func(cacheData CacheKeyData, automation DatastoreAutomation) {
-					err := handleRunDatastoreAutomation(cacheData, automation)
+					err := handleRunDatastoreAutomation(ctx, cacheData, automation)
 					if err != nil {
 						log.Printf("[ERROR] Failed running automation %s for cache key %s: %s", automation.Name, cacheData.Key, err)
 

--- a/db-connector.go
+++ b/db-connector.go
@@ -2416,7 +2416,12 @@ func Fixexecution(ctx context.Context, workflowExecution WorkflowExecution) (Wor
 
 		for _, result := range workflowExecution.Results {
 			if result.Status == "FAILURE" || result.Status == "ABORTED" {
-				log.Printf("[DEBUG][%s] Setting execution to aborted because of result %s (%s) with status '%s'. Should update execution parent if it exists (not implemented).", workflowExecution.ExecutionId, result.Action.Name, result.Action.ID, result.Status)
+				// Only log once per execution to avoid spam
+				cacheKey := fmt.Sprintf("abort_log_%s", workflowExecution.ExecutionId)
+				if _, err := GetCache(ctx, cacheKey); err != nil {
+					log.Printf("[DEBUG][%s] Setting execution to aborted because of result %s (%s) with status '%s'. Should update execution parent if it exists (not implemented).", workflowExecution.ExecutionId, result.Action.Name, result.Action.ID, result.Status)
+					SetCache(ctx, cacheKey, []byte("logged"), 5) // 5 minute TTL
+				}
 
 				workflowExecution.Status = "ABORTED"
 				dbsave = true

--- a/db-connector.go
+++ b/db-connector.go
@@ -2067,7 +2067,7 @@ func Fixexecution(ctx context.Context, workflowExecution WorkflowExecution) (Wor
 						finishedDecisions = append(finishedDecisions, decision.RunDetails.Id)
 						continue
 					} else if decision.RunDetails.Status == "FAILURE" {
-						finishedDecisions = append(finishedDecisions, decision.RunDetails.Id)
+						//finishedDecisions = append(finishedDecisions, decision.RunDetails.Id)
 						failedFound = true
 						continue
 					} else if decision.RunDetails.Status == "RUNNING" && decision.Action != "ask" {
@@ -2082,8 +2082,8 @@ func Fixexecution(ctx context.Context, workflowExecution WorkflowExecution) (Wor
 							mappedOutput.Decisions[decisionIndex].RunDetails.RawResponse += "\n[ERROR] Decision marked as FAILURE due to 5 minute timeout."
 
 							// Count this as finished + failed so recovery triggers in the same Fixexecution run
-							finishedDecisions = append(finishedDecisions, decision.RunDetails.Id)
-							failedFound = true
+							// finishedDecisions = append(finishedDecisions, decision.RunDetails.Id)
+							// failedFound = true
 						}
 					} else {
 						if decision.RunDetails.CompletedAt > 0 {
@@ -2186,7 +2186,8 @@ func Fixexecution(ctx context.Context, workflowExecution WorkflowExecution) (Wor
 							go sendAgentActionSelfRequest("SUCCESS", workflowExecution, workflowExecution.Results[resultIndex])
 						}()
 					} else {
-						log.Printf("[INFO][%s] All decisions finished for agent action %s - but no finish action found. Re-invoking agent to finalize (failedFound: %t).", workflowExecution.ExecutionId, action.ID, failedFound)
+						log.Printf("[INFO][%s] All decisions finished for agent action %s - but no finish action found, marking as WAITING.", workflowExecution.ExecutionId, action.ID)
+						//log.Printf("[INFO][%s] All decisions finished for agent action %s - but no finish action found. Re-invoking agent to finalize (failedFound: %t).", workflowExecution.ExecutionId, action.ID, failedFound)
 
 						mappedOutput.Status = "RUNNING"
 						mappedOutput.CompletedAt = 0
@@ -2195,17 +2196,19 @@ func Fixexecution(ctx context.Context, workflowExecution WorkflowExecution) (Wor
 						if workflowExecution.Status == "FINISHED" {
 							workflowExecution.Status = "EXECUTING"
 						}
-
+						// To ensure the execution is actually updated
 						// Re-invoke the agent so the LLM can see the failure and produce a proper "finish" decision.
 
-						capturedExec := workflowExecution
-						capturedAction := action
+						// capturedExec := workflowExecution
+						// capturedAction := action
 						go func() {
-							time.Sleep(2 * time.Second)
-							_, err := HandleAiAgentExecutionStart(capturedExec, capturedAction, true)
-							if err != nil {
-								log.Printf("[ERROR][%s] Failed re-invoking agent after decisions completed for action %s: %s", capturedExec.ExecutionId, capturedAction.ID, err)
-							}
+							time.Sleep(1 * time.Second)
+							sendAgentActionSelfRequest("WAITING", workflowExecution, workflowExecution.Results[resultIndex])
+							// time.Sleep(2 * time.Second)
+							// _, err := HandleAiAgentExecutionStart(capturedExec, capturedAction, true)
+							// if err != nil {
+							// 	log.Printf("[ERROR][%s] Failed re-invoking agent after decisions completed for action %s: %s", capturedExec.ExecutionId, capturedAction.ID, err)
+							// }
 						}()
 					}
 				} else if (result.Status == "" || result.Status == "WAITING") && mappedOutput.Status == "FINISHED" {

--- a/db-connector.go
+++ b/db-connector.go
@@ -2067,7 +2067,7 @@ func Fixexecution(ctx context.Context, workflowExecution WorkflowExecution) (Wor
 						finishedDecisions = append(finishedDecisions, decision.RunDetails.Id)
 						continue
 					} else if decision.RunDetails.Status == "FAILURE" {
-						//finishedDecisions = append(finishedDecisions, decision.RunDetails.Id)
+						finishedDecisions = append(finishedDecisions, decision.RunDetails.Id)
 						failedFound = true
 						continue
 					} else if decision.RunDetails.Status == "RUNNING" && decision.Action != "ask" {
@@ -2080,8 +2080,11 @@ func Fixexecution(ctx context.Context, workflowExecution WorkflowExecution) (Wor
 							mappedOutput.Decisions[decisionIndex].RunDetails.Status = "FAILURE"
 							mappedOutput.Decisions[decisionIndex].RunDetails.CompletedAt = time.Now().Unix()
 							mappedOutput.Decisions[decisionIndex].RunDetails.RawResponse += "\n[ERROR] Decision marked as FAILURE due to 5 minute timeout."
-						}
 
+							// Count this as finished + failed so recovery triggers in the same Fixexecution run
+							finishedDecisions = append(finishedDecisions, decision.RunDetails.Id)
+							failedFound = true
+						}
 					} else {
 						if decision.RunDetails.CompletedAt > 0 {
 							if debug {
@@ -2183,7 +2186,7 @@ func Fixexecution(ctx context.Context, workflowExecution WorkflowExecution) (Wor
 							go sendAgentActionSelfRequest("SUCCESS", workflowExecution, workflowExecution.Results[resultIndex])
 						}()
 					} else {
-						log.Printf("[INFO][%s] All decisions finished for agent action %s - but no finish action found, marking as WAITING.", workflowExecution.ExecutionId, action.ID)
+						log.Printf("[INFO][%s] All decisions finished for agent action %s - but no finish action found. Re-invoking agent to finalize (failedFound: %t).", workflowExecution.ExecutionId, action.ID, failedFound)
 
 						mappedOutput.Status = "RUNNING"
 						mappedOutput.CompletedAt = 0
@@ -2193,10 +2196,16 @@ func Fixexecution(ctx context.Context, workflowExecution WorkflowExecution) (Wor
 							workflowExecution.Status = "EXECUTING"
 						}
 
-						// To ensure the execution is actually updated
+						// Re-invoke the agent so the LLM can see the failure and produce a proper "finish" decision.
+
+						capturedExec := workflowExecution
+						capturedAction := action
 						go func() {
-							time.Sleep(1 * time.Second)
-							sendAgentActionSelfRequest("WAITING", workflowExecution, workflowExecution.Results[resultIndex])
+							time.Sleep(2 * time.Second)
+							_, err := HandleAiAgentExecutionStart(capturedExec, capturedAction, true)
+							if err != nil {
+								log.Printf("[ERROR][%s] Failed re-invoking agent after decisions completed for action %s: %s", capturedExec.ExecutionId, capturedAction.ID, err)
+							}
 						}()
 					}
 				} else if (result.Status == "" || result.Status == "WAITING") && mappedOutput.Status == "FINISHED" {

--- a/shared.go
+++ b/shared.go
@@ -189,7 +189,7 @@ func HandleCors(resp http.ResponseWriter, request *http.Request) bool {
 	}
 
 	//resp.Header().Set("Access-Control-Allow-Origin", "http://localhost:8000")
-	resp.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With, remember-me, Org-Id, Org, Authorization, X-Debug-Url")
+	resp.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With, remember-me, Org-Id, Org, Authorization, X-Debug-Url, X-Internal-Caller, X-Trace-ID")
 	resp.Header().Set("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE, PATCH")
 	resp.Header().Set("Access-Control-Allow-Credentials", "true")
 

--- a/shared.go
+++ b/shared.go
@@ -17600,6 +17600,8 @@ func handleAgentDecisionStreamResult(workflowExecution WorkflowExecution, action
 		log.Printf("[DEBUG][%s] Got decision ID '%s' for agent '%s'. Ref: %s", workflowExecution.ExecutionId, decisionId, actionResult.Action.ID, actionResult.Status)
 	}
 
+	ctx := context.Background()
+
 	foundActionResultIndex := -1
 	for actionIndex, result := range workflowExecution.Results {
 		if result.Action.ID == actionResult.Action.ID {
@@ -17823,7 +17825,6 @@ func handleAgentDecisionStreamResult(workflowExecution WorkflowExecution, action
 			log.Printf("[DEBUG] Getting agent chat history: %s", requestKey)
 		}
 
-		ctx := context.Background()
 		agentRequestMemory, err := GetDatastoreKey(ctx, requestKey, "agent_requests")
 		if err != nil {
 			log.Printf("[ERROR][%s] Failed to find request memory for updates", actionResult.ExecutionId)
@@ -17848,7 +17849,7 @@ func handleAgentDecisionStreamResult(workflowExecution WorkflowExecution, action
 			originalAction = actionResult.Action
 		}
 
-		returnAction, err := HandleAiAgentExecutionStart(workflowExecution, originalAction, true, "handleAgentDecisionStreamResult", "")
+		returnAction, err := HandleAiAgentExecutionStart(ctx, workflowExecution, originalAction, true)
 		if err != nil {
 			log.Printf("[ERROR][%s] Failed handling agent execution start: %s", workflowExecution.ExecutionId, err)
 		}
@@ -21810,9 +21811,12 @@ func CheckHookAuth(request *http.Request, auth string) error {
 }
 
 // Body = The action body received from the user to test.
-func PrepareSingleAction(ctx context.Context, parentRequest *http.Request, user User, appId string, body []byte, runValidationAction bool, caller string, traceID string, decision ...string) (WorkflowExecution, error) {
+func PrepareSingleAction(ctx context.Context, parentRequest *http.Request, user User, appId string, body []byte, runValidationAction bool, decision ...string) (WorkflowExecution, error) {
 
 	workflowExecution := WorkflowExecution{}
+	if ctx == nil {
+        ctx = context.Background() 
+    }
 
 	var action Action
 	err := json.Unmarshal(body, &action)
@@ -21877,7 +21881,10 @@ func PrepareSingleAction(ctx context.Context, parentRequest *http.Request, user 
 				}
 			}
 
-			action, err := HandleAiAgentExecutionStart(exec, action, false, caller, traceID)
+			caller, _ := ctx.Value("caller").(string)
+    		traceID, _ := ctx.Value("trace_id").(string)
+
+			action, err := HandleAiAgentExecutionStart(ctx, exec, action, false)
 			if err != nil {
 				log.Printf("[ERROR] Failed to handle AI agent execution start: %s", err)
 			}

--- a/shared.go
+++ b/shared.go
@@ -17407,6 +17407,7 @@ func sendAgentActionSelfRequest(status string, workflowExecution WorkflowExecuti
 
 	// Check if the request has been sent already (just in case)
 	cacheKey := fmt.Sprintf("agent_request_%s_%s_%s", workflowExecution.ExecutionId, actionResult.Action.ID, status)
+	// cacheKey := fmt.Sprintf("agent_request_%s_%s", workflowExecution.ExecutionId, actionResult.Action.ID)
 	_, err := GetCache(ctx, cacheKey)
 	if err == nil {
 		//if debug {
@@ -17420,6 +17421,7 @@ func sendAgentActionSelfRequest(status string, workflowExecution WorkflowExecuti
 			cacheTTL = 1440 // 24 hours — execution outcome is permanent
 		}
 		SetCache(ctx, cacheKey, []byte("1"), cacheTTL)
+		// SetCache(ctx, cacheKey, []byte(status), cacheTTL)
 	}
 
 	if status == "SUCCESS" || status == "FINISHED" || status == "FAILURE" || status == "ABORTED" {

--- a/shared.go
+++ b/shared.go
@@ -22334,13 +22334,13 @@ func PrepareSingleAction(ctx context.Context, parentRequest *http.Request, user 
 		workflowExecution.OrgId = user.ActiveOrg.Id
 	}
 
-	formattedAppName := strings.ReplaceAll(strings.ToLower(app.Name), " ", "_")
+	// formattedAppName := strings.ReplaceAll(strings.ToLower(app.Name), " ", "_")
 
-	isInternalShuffleApp := false
-	switch formattedAppName {
-	case "shuffle_datastore", "shuffle_org_management", "shuffle_app_management", "shuffle_workflow_management":
-		isInternalShuffleApp = true
-	}
+	// isInternalShuffleApp := false
+	// switch formattedAppName {
+	// case "shuffle_datastore", "shuffle_org_management", "shuffle_app_management", "shuffle_workflow_management":
+	// 	isInternalShuffleApp = true
+	// }
 
 	if len(app.Name) == 0 && len(action.AppName) > 0 {
 		app.Name = action.AppName

--- a/shared.go
+++ b/shared.go
@@ -21885,6 +21885,11 @@ func PrepareSingleAction(ctx context.Context, parentRequest *http.Request, user 
 
 			caller, _ := ctx.Value("caller").(string)
     		traceID, _ := ctx.Value("trace_id").(string)
+			if strings.TrimSpace(caller) == "" {
+				caller = "PrepareSingleAction"
+			}
+
+			ctx = context.WithValue(ctx, "caller", caller)
 
 			action, err := HandleAiAgentExecutionStart(ctx, exec, action, false)
 			if err != nil {

--- a/shared.go
+++ b/shared.go
@@ -21897,7 +21897,7 @@ func PrepareSingleAction(ctx context.Context, parentRequest *http.Request, user 
 			exec.Workflow.Actions[0] = action
 
 			newExec, err := GetWorkflowExecution(ctx, exec.ExecutionId)
-			log.Printf("[INFO][%s] AI Agent: %s Started standalone for org %s, execution id %s, workflow %s, with trace-id %s", exec.ExecutionId, caller, user.ActiveOrg.Id, exec.ExecutionId, exec.WorkflowId, traceID)
+			log.Printf("[INFO][%s] AI Agent: %s Started standalone for org %s, execution id %s, workflow %s", exec.ExecutionId, caller, user.ActiveOrg.Id, exec.ExecutionId, exec.WorkflowId)
 			if err != nil {
 				log.Printf("[ERROR] Failed to get workflow execution after starting agent: %s", err)
 			} else {

--- a/shared.go
+++ b/shared.go
@@ -189,7 +189,7 @@ func HandleCors(resp http.ResponseWriter, request *http.Request) bool {
 	}
 
 	//resp.Header().Set("Access-Control-Allow-Origin", "http://localhost:8000")
-	resp.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With, remember-me, Org-Id, Org, Authorization, X-Debug-Url, X-Internal-Caller, X-Trace-ID")
+	resp.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With, remember-me, Org-Id, Org, Authorization, X-Debug-Url")
 	resp.Header().Set("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE, PATCH")
 	resp.Header().Set("Access-Control-Allow-Credentials", "true")
 
@@ -21884,7 +21884,6 @@ func PrepareSingleAction(ctx context.Context, parentRequest *http.Request, user 
 			}
 
 			caller, _ := ctx.Value("caller").(string)
-    		traceID, _ := ctx.Value("trace_id").(string)
 			if strings.TrimSpace(caller) == "" {
 				caller = "PrepareSingleAction"
 			}

--- a/shared.go
+++ b/shared.go
@@ -17415,7 +17415,11 @@ func sendAgentActionSelfRequest(status string, workflowExecution WorkflowExecuti
 
 		return nil
 	} else {
-		SetCache(ctx, cacheKey, []byte("1"), 1)
+		var cacheTTL int32 = 1 // 1 minute for non-terminal statuses
+		if status == "SUCCESS" || status == "FINISHED" || status == "FAILURE" || status == "ABORTED" {
+			cacheTTL = 1440 // 24 hours — execution outcome is permanent
+		}
+		SetCache(ctx, cacheKey, []byte("1"), cacheTTL)
 	}
 
 	if status == "SUCCESS" || status == "FINISHED" || status == "FAILURE" || status == "ABORTED" {

--- a/shared.go
+++ b/shared.go
@@ -17848,7 +17848,7 @@ func handleAgentDecisionStreamResult(workflowExecution WorkflowExecution, action
 			originalAction = actionResult.Action
 		}
 
-		returnAction, err := HandleAiAgentExecutionStart(workflowExecution, originalAction, true)
+		returnAction, err := HandleAiAgentExecutionStart(workflowExecution, originalAction, true, "handleAgentDecisionStreamResult", "")
 		if err != nil {
 			log.Printf("[ERROR][%s] Failed handling agent execution start: %s", workflowExecution.ExecutionId, err)
 		}
@@ -21810,7 +21810,7 @@ func CheckHookAuth(request *http.Request, auth string) error {
 }
 
 // Body = The action body received from the user to test.
-func PrepareSingleAction(ctx context.Context, parentRequest *http.Request, user User, appId string, body []byte, runValidationAction bool, decision ...string) (WorkflowExecution, error) {
+func PrepareSingleAction(ctx context.Context, parentRequest *http.Request, user User, appId string, body []byte, runValidationAction bool, caller string, traceID string, decision ...string) (WorkflowExecution, error) {
 
 	workflowExecution := WorkflowExecution{}
 
@@ -21877,13 +21877,14 @@ func PrepareSingleAction(ctx context.Context, parentRequest *http.Request, user 
 				}
 			}
 
-			action, err := HandleAiAgentExecutionStart(exec, action, false)
+			action, err := HandleAiAgentExecutionStart(exec, action, false, caller, traceID)
 			if err != nil {
 				log.Printf("[ERROR] Failed to handle AI agent execution start: %s", err)
 			}
 			exec.Workflow.Actions[0] = action
 
 			newExec, err := GetWorkflowExecution(ctx, exec.ExecutionId)
+			log.Printf("[INFO][%s] AI Agent: %s Started standalone for org %s, execution id %s, workflow %s, with trace-id %s", exec.ExecutionId, caller, user.ActiveOrg.Id, exec.ExecutionId, exec.WorkflowId, traceID)
 			if err != nil {
 				log.Printf("[ERROR] Failed to get workflow execution after starting agent: %s", err)
 			} else {

--- a/shared.go
+++ b/shared.go
@@ -17851,7 +17851,8 @@ func handleAgentDecisionStreamResult(workflowExecution WorkflowExecution, action
 			originalAction = actionResult.Action
 		}
 
-		returnAction, err := HandleAiAgentExecutionStart(ctx, workflowExecution, originalAction, true)
+		callerName := "handleAgentDecisionStreamResult"
+		returnAction, err := HandleAiAgentExecutionStart(workflowExecution, originalAction, true, callerName)
 		if err != nil {
 			log.Printf("[ERROR][%s] Failed handling agent execution start: %s", workflowExecution.ExecutionId, err)
 		}
@@ -21883,21 +21884,15 @@ func PrepareSingleAction(ctx context.Context, parentRequest *http.Request, user 
 				}
 			}
 
-			caller, _ := ctx.Value("caller").(string)
-			if strings.TrimSpace(caller) == "" {
-				caller = "PrepareSingleAction"
-			}
-
-			ctx = context.WithValue(ctx, "caller", caller)
-
-			action, err := HandleAiAgentExecutionStart(ctx, exec, action, false)
+			callerName := "PrepareSingleAction"
+			action, err := HandleAiAgentExecutionStart(exec, action, false, callerName)
 			if err != nil {
 				log.Printf("[ERROR] Failed to handle AI agent execution start: %s", err)
 			}
 			exec.Workflow.Actions[0] = action
 
 			newExec, err := GetWorkflowExecution(ctx, exec.ExecutionId)
-			log.Printf("[INFO][%s] AI Agent: %s Started standalone for org %s, execution id %s, workflow %s", exec.ExecutionId, caller, user.ActiveOrg.Id, exec.ExecutionId, exec.WorkflowId)
+			log.Printf("[INFO][%s] AI Agent: %s Started standalone for org %s, execution id %s, workflow %s", exec.ExecutionId, callerName, user.ActiveOrg.Id, exec.ExecutionId, exec.WorkflowId)
 			if err != nil {
 				log.Printf("[ERROR] Failed to get workflow execution after starting agent: %s", err)
 			} else {
@@ -22351,14 +22346,6 @@ func PrepareSingleAction(ctx context.Context, parentRequest *http.Request, user 
 		workflowExecution.ExecutionOrg = user.ActiveOrg.Id
 		workflowExecution.OrgId = user.ActiveOrg.Id
 	}
-
-	// formattedAppName := strings.ReplaceAll(strings.ToLower(app.Name), " ", "_")
-
-	// isInternalShuffleApp := false
-	// switch formattedAppName {
-	// case "shuffle_datastore", "shuffle_org_management", "shuffle_app_management", "shuffle_workflow_management":
-	// 	isInternalShuffleApp = true
-	// }
 
 	if len(app.Name) == 0 && len(action.AppName) > 0 {
 		app.Name = action.AppName

--- a/shared.go
+++ b/shared.go
@@ -17836,7 +17836,15 @@ func handleAgentDecisionStreamResult(workflowExecution WorkflowExecution, action
 		// Handle agent decisionmaking. Use the same
 		log.Printf("[INFO][%s] With the agent being finished, we are asking it whether it would like to do anything else", workflowExecution.ExecutionId)
 
-		returnAction, err := HandleAiAgentExecutionStart(workflowExecution, actionResult.Action, true)
+		var originalAction Action
+		if foundActionResultIndex >= 0 && foundActionResultIndex < len(workflowExecution.Results) {
+			originalAction = workflowExecution.Results[foundActionResultIndex].Action
+		} else {
+			// Fallback in case of an issue
+			originalAction = actionResult.Action
+		}
+
+		returnAction, err := HandleAiAgentExecutionStart(workflowExecution, originalAction, true)
 		if err != nil {
 			log.Printf("[ERROR][%s] Failed handling agent execution start: %s", workflowExecution.ExecutionId, err)
 		}
@@ -22324,6 +22332,14 @@ func PrepareSingleAction(ctx context.Context, parentRequest *http.Request, user 
 		workflow.ExecutingOrg = user.ActiveOrg
 		workflowExecution.ExecutionOrg = user.ActiveOrg.Id
 		workflowExecution.OrgId = user.ActiveOrg.Id
+	}
+
+	formattedAppName := strings.ReplaceAll(strings.ToLower(app.Name), " ", "_")
+
+	isInternalShuffleApp := false
+	switch formattedAppName {
+	case "shuffle_datastore", "shuffle_org_management", "shuffle_app_management", "shuffle_workflow_management":
+		isInternalShuffleApp = true
 	}
 
 	if len(app.Name) == 0 && len(action.AppName) > 0 {


### PR DESCRIPTION
 Here are the key changes:

- Changed abort status from `"FINISHED"` to `"ABORTED"` throughout the codebase for clearer execution state tracking
- Moved abort logic into the `abortAgentExecution()` function, replacing repetitive error handling code in ~7 locations
- Fixed Action Reference bug where the wrong action object was being passed to the agent continuation logic. Previously, it was using actionResult.Action, but now it properly retrieves the original action from the execution results array, ensuring the agent has the correct state and context when continuing execution. (Look at line 17846 in `shared.go`)
- Added context (`ctx`) as a parameter to `HandleAiAgentExecutionStart()` 
- Added validation for caller function info with trace ID logging for better debugging
- Added `"http"` into the list of available apps for agent decisions), making the agent work with HTTP functionality again.

- Added `AI_AGENT_LLM_FAILURE` log prefix for all LLM-related errors
- Includes detailed error context: org ID, status codes, error types, and raw responses
- Helps distinguish between different failure modes (auth errors, rate limits, parsing errors, etc.)
- Added caller function and trace ID logging for agent starts
- Better separation between `ABORTED`, `FAILURE`, and `FINISHED` states
