### PR TITLE
Fix - duplicate alert issue

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -2,7 +2,7 @@ package shuffle
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"log"
@@ -1427,7 +1427,7 @@ func generateAlertCacheKey(orgId string, threshold interface{}, emailList []stri
 
 	// Memcache keys have a 250-character limit. Hash anything that exceeds it.
 	if len(key) > 200 {
-		hash := md5.Sum([]byte(key))
+		hash := sha256.Sum256([]byte(key))
 		key = "alert_cache_" + hex.EncodeToString(hash[:])
 	}
 

--- a/stats.go
+++ b/stats.go
@@ -2,6 +2,8 @@ package shuffle
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"sort"
@@ -1423,6 +1425,12 @@ func generateAlertCacheKey(orgId string, threshold interface{}, emailList []stri
 	key = strings.ReplaceAll(key, ".", "_dot_")
 	key = strings.ReplaceAll(key, " ", "_")
 
+	// Memcache keys have a 250-character limit. Hash anything that exceeds it.
+	if len(key) > 200 {
+		hash := md5.Sum([]byte(key))
+		key = "alert_cache_" + hex.EncodeToString(hash[:])
+	}
+
 	return key
 }
 
@@ -1432,7 +1440,7 @@ func checkAndSetAlertCache(ctx context.Context, cacheKey string) bool {
 		return false
 	}
 
-	err = SetCache(ctx, cacheKey, []byte("sent"), 60)
+	err = SetCache(ctx, cacheKey, []byte("sent"), 1440)
 	if err != nil {
 		log.Printf("[WARNING] Failed setting alert cache for key %s: %s", cacheKey, err)
 	}


### PR DESCRIPTION
Issue: Memcache was not being set due to cache key length was more than 250 character

Fix: Hash cache key when it is more than 200 characters and increase TTL for 1 alert send from 60 minute to 1 day. 