### PR TITLE
make usage alert cache timeout dymanic

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -1623,7 +1623,7 @@ func HandleIncrement(dataType string, orgStatistics *ExecutionInfo, increment ui
 	for _, alert := range org.Billing.AlertThreshold {
 		found := false
 		for _, statAlert := range orgStatistics.UsageAlerts {
-			if statAlert.Percentage == alert.Percentage || statAlert.Count == alert.Count {
+			if statAlert.Percentage == alert.Percentage && statAlert.Count == alert.Count {
 				found = true
 				break
 			}

--- a/stats.go
+++ b/stats.go
@@ -1440,7 +1440,14 @@ func checkAndSetAlertCache(ctx context.Context, cacheKey string) bool {
 		return false
 	}
 
-	err = SetCache(ctx, cacheKey, []byte("sent"), 1440)
+	now := time.Now()
+	endOfMonth := time.Date(now.Year(), now.Month()+1, 1, 0, 0, 0, 0, now.Location())
+	remainingMinutes := int32(endOfMonth.Sub(now).Minutes())
+	if remainingMinutes < 60 {
+		remainingMinutes = 60
+	}
+
+	err = SetCache(ctx, cacheKey, []byte("sent"), remainingMinutes)
 	if err != nil {
 		log.Printf("[WARNING] Failed setting alert cache for key %s: %s", cacheKey, err)
 	}


### PR DESCRIPTION
**Issues**

1.  In some cases, the same alert is sent multiple times for a single threshold, even though `email_send` is already marked as true in the db.
2.  Alert not being added in the org_stats when app run limit is changed for example from 2K to 10K

**Fix:** 
1. Instead of depending on the database, use a cache and set its timeout to for the remaining days of the month for that alert.
2. When org app runs limit is changed in this case make sure to add alert for changed app runs in org_statistics by making sure both percentage and app runs counts for match in org_stats. Curently, it is checking only any one of them.