### PR TITLE
fix - cloud sync and workflow changes issue

### DIFF
--- a/db-connector.go
+++ b/db-connector.go
@@ -9800,10 +9800,9 @@ func SetWorkflow(ctx context.Context, workflow Workflow, id string, optionalEdit
 
 		// Find the key for "workflows_<workflow.org_id>" and update the cache for this one. If it doesn't exist, add it
 		// Get the cache for the workflows
-		cursor := ""
-		DeleteCache(ctx, fmt.Sprintf("%s_workflows", "", workflow.OrgId))
+		DeleteCache(ctx, fmt.Sprintf("%s_workflows", workflow.OrgId))
 
-		cacheKey = fmt.Sprintf("%s_%s_workflows", cursor, workflow.OrgId)
+		cacheKey = fmt.Sprintf("%s_workflows", workflow.OrgId)
 		cache, err := GetCache(ctx, cacheKey)
 		if err != nil {
 			//log.Printf("[WARNING] Failed getting cache for getworkflow '%s': %s", cacheKey, err)

--- a/shared.go
+++ b/shared.go
@@ -33606,7 +33606,7 @@ func HandleCheckLicense(ctx context.Context, org Org) Org {
 						org.SyncFeatures.Branding.Active = features.Branding.Active
 
 						org.SyncFeatures.AppExecutions.Active = features.OnpremAppExecutions.Active
-						if features.AppExecutions.Limit < 25000 {
+						if features.OnpremAppExecutions.Limit < 25000 {
 							org.SyncFeatures.AppExecutions.Limit = 25000
 						} else {
 							org.SyncFeatures.AppExecutions.Limit = features.OnpremAppExecutions.Limit
@@ -33675,6 +33675,9 @@ func HandleCheckLicense(ctx context.Context, org Org) Org {
 
 				org.SyncFeatures.Authentication.Active = features.Authentication.Active
 				org.SyncFeatures.Authentication.Limit = features.Authentication.Limit
+
+				org.SyncFeatures.WorkflowExecutions.Active = features.WorkflowExecutions.Active
+				org.SyncFeatures.WorkflowExecutions.Limit = features.WorkflowExecutions.Limit
 
 				org.SyncFeatures.Schedule.Active = features.Schedule.Active
 				org.SyncFeatures.Schedule.Limit = features.Schedule.Limit


### PR DESCRIPTION
Issue:

1. Workflow executions were showing as disabled on the UI with cloud sync, even when they were enabled.
2. When the workflow name or nodes changed, the workflow name on the `/workflows` page was not updating, and the old image was still being shown.

Fix:

1. Get the workflow executions from the sync cache and update the status and limit from the cloud sync.
2. Invalidate the cache when saving without an empty cursor key.
