### PR TITLE
fix - opensearch health storing issue

### DIFF
--- a/health.go
+++ b/health.go
@@ -1030,6 +1030,7 @@ func GetOpsDashboardStats(resp http.ResponseWriter, request *http.Request) {
 	limit := request.URL.Query().Get("limit")
 	before := request.URL.Query().Get("before")
 	after := request.URL.Query().Get("after")
+	isOnprem := request.URL.Query().Get("onprem")
 
 	// convert all to int64
 	limitInt, err := strconv.Atoi(limit)
@@ -1048,6 +1049,47 @@ func GetOpsDashboardStats(resp http.ResponseWriter, request *http.Request) {
 	afterInt, err := strconv.Atoi(after)
 	if err != nil {
 		afterInt = int(time.Now().AddDate(0, 0, -30).Unix())
+	}
+
+	if isOnprem == "true" {
+		onpremServerUrl := os.Getenv("SHUFFLE_ONPREM_SERVER_URL")
+		if len(onpremServerUrl) == 0 {
+			log.Printf("[ERROR] onprem is set to true but SHUFFLE_ONPREM_SERVER_URL is not set")
+			resp.WriteHeader(500)
+			resp.Write([]byte(`{"success": false, "reason": "onprem is set to true but SHUFFLE_ONPREM_SERVER_URL is not set"}`))
+			return
+		}
+
+		url := onpremServerUrl + "/api/v1/health/stats?limit=" + strconv.Itoa(limitInt) + "&before=" + strconv.Itoa(beforeInt) + "&after=" + strconv.Itoa(afterInt)
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			log.Printf("[ERROR] Failed creating HTTP request to onprem server: %s", err)
+			resp.WriteHeader(500)
+			resp.Write([]byte(`{"success": false, "reason": "Failed creating HTTP request to onprem server."}`))
+			return
+		}
+
+		client := &http.Client{Timeout: 180 * time.Second}
+		response, err := client.Do(req)
+		if err != nil {
+			log.Printf("[ERROR] Failed sending HTTP request to onprem server: %s", err)
+			resp.WriteHeader(500)
+			resp.Write([]byte(`{"success": false, "reason": "Failed sending HTTP request to onprem server."}`))
+			return
+		}
+
+		defer response.Body.Close()
+		body, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			log.Printf("[ERROR] Failed reading response body from onprem server: %s", err)
+			resp.WriteHeader(500)
+			resp.Write([]byte(`{"success": false, "reason": "Failed reading response body from onprem server."}`))
+			return
+		}
+
+		resp.WriteHeader(response.StatusCode)
+		resp.Write(body)
+		return
 	}
 
 	healthChecks, err := GetPlatformHealth(ctx, afterInt, beforeInt, limitInt)

--- a/health.go
+++ b/health.go
@@ -915,6 +915,7 @@ func RunOpsHealthCheck(resp http.ResponseWriter, request *http.Request) {
 	HealthCheck.FileOps = platformHealth.FileOps
 	HealthCheck.Apps = platformHealth.Apps
 	HealthCheck.Agents = platformHealth.Agents
+	HealthCheck.Opensearch = platformHealth.OpensearchOps
 	// Add to database
 	err = SetPlatformHealth(ctx, HealthCheck)
 	if err != nil {

--- a/structs.go
+++ b/structs.go
@@ -4513,7 +4513,7 @@ type HealthCheckDB struct {
 	Updated    int64                           `json:"updated"`
 	Workflows  WorkflowHealth                  `json:"workflows"`
 	Agents     AgentHealth                     `json:"agents"`
-	Opensearch opensearchapi.ClusterHealthResp `json:"opnsearch"`
+	Opensearch opensearchapi.ClusterHealthResp `json:"opensearch"`
 	Datastore  DatastoreHealth                 `json:"datastore"`
 	FileOps    FileHealth                      `json:"fileops"`
 	Apps       AppHealth                       `json:"apps"`


### PR DESCRIPTION
1. Store OpenSearch health in the database on every health check run.
2. Get the on-prem health stats on the health page.