### PR TITLE
Fix child_org_agent metrics tracking and AI Model change

### DIFF
--- a/ai.go
+++ b/ai.go
@@ -9484,16 +9484,22 @@ data_filter:
 
 					// resultMapping.Status = "FAILURE"
 					// LLM returned a proper error (401 invalid key, 429 rate limit, 500 server error, etc.)
+					abortReason := "llm_http_error"
+					abortMessage := fmt.Sprintf("LLM error (HTTP %d %s): %s", outputMap.Status, newOutput.Error.Type, newOutput.Error.Message)
+
 					if outputMap.Status == 429 {
 						rateLimitKey := "openai_rate_limit_log"
 						if _, cacheErr := GetCache(ctx, rateLimitKey); cacheErr != nil {
 							log.Printf("[ERROR][%s] AI_OPENAI_RATE_LIMIT: org=%s error_message=%s", execution.ExecutionId, execution.Workflow.OrgId, newOutput.Error.Message)
 							_ = SetCache(ctx, rateLimitKey, []byte("1"), 30)
 						}
+						abortReason = "llm_rate_limit"
+						abortMessage = "Agent execution failed due to rate limits. Please try again or contact support at support@shuffler.io"
 					} else {
 						log.Printf("[ERROR][%s] AI_AGENT_LLM_FAILURE: org=%s status_code=%d error_type=%s error_message=%s", execution.ExecutionId, execution.Workflow.OrgId, outputMap.Status, newOutput.Error.Type, newOutput.Error.Message)
 					}
-					return abortAgentExecution(ctx, execution, startNode, oldAgentOutput, "llm_http_error", fmt.Sprintf("LLM error (HTTP %d %s): %s", outputMap.Status, newOutput.Error.Type, newOutput.Error.Message))
+
+					return abortAgentExecution(ctx, execution, startNode, oldAgentOutput, abortReason, abortMessage)
 				} else {
 					log.Printf("[ERROR][%s] AI Agent: No choices, nor error found in AI agent response. Status: %d. Raw: %s", execution.ExecutionId, outputMap.Status, bodyString)
 					resultMapping.Status = "FAILURE"

--- a/ai.go
+++ b/ai.go
@@ -8914,7 +8914,7 @@ data_filter:
 	}
 
 	// Set model based on environment
-	aiModel := "gpt-5.4-mini-2026-03-17"
+	aiModel := "gpt-5.6-luna"
 	newAiModel := os.Getenv("AI_MODEL")
 	if newAiModel == "" {
 		newAiModel = os.Getenv("OPENAI_MODEL")

--- a/stats.go
+++ b/stats.go
@@ -1611,6 +1611,34 @@ func HandleIncrement(dataType string, orgStatistics *ExecutionInfo, increment ui
 		orgStatistics.TotalAgentCachedTokens += int64(increment)
 		orgStatistics.MonthlyAgentCachedTokens += int64(increment)
 		orgStatistics.DailyAgentCachedTokens += int64(increment)
+	} else if dataType == "child_org_agent_executions" {
+		orgStatistics.TotalChildOrgAgentExecutions += int64(increment)
+		orgStatistics.MonthlyChildOrgAgentExecutions += int64(increment)
+		orgStatistics.DailyChildOrgAgentExecutions += int64(increment)
+	} else if dataType == "child_org_agent_executions_successful" {
+		orgStatistics.TotalChildOrgAgentExecutionsSuccessful += int64(increment)
+		orgStatistics.MonthlyChildOrgAgentExecutionsSuccessful += int64(increment)
+		orgStatistics.DailyChildOrgAgentExecutionsSuccessful += int64(increment)
+	} else if dataType == "child_org_agent_executions_failed" {
+		orgStatistics.TotalChildOrgAgentExecutionsFailed += int64(increment)
+		orgStatistics.MonthlyChildOrgAgentExecutionsFailed += int64(increment)
+		orgStatistics.DailyChildOrgAgentExecutionsFailed += int64(increment)
+	} else if dataType == "child_org_agent_tokens" {
+		orgStatistics.TotalChildOrgAgentTokens += int64(increment)
+		orgStatistics.MonthlyChildOrgAgentTokens += int64(increment)
+		orgStatistics.DailyChildOrgAgentTokens += int64(increment)
+	} else if dataType == "child_org_agent_input_tokens" {
+		orgStatistics.TotalChildOrgAgentInputTokens += int64(increment)
+		orgStatistics.MonthlyChildOrgAgentInputTokens += int64(increment)
+		orgStatistics.DailyChildOrgAgentInputTokens += int64(increment)
+	} else if dataType == "child_org_agent_output_tokens" {
+		orgStatistics.TotalChildOrgAgentOutputTokens += int64(increment)
+		orgStatistics.MonthlyChildOrgAgentOutputTokens += int64(increment)
+		orgStatistics.DailyChildOrgAgentOutputTokens += int64(increment)
+	} else if dataType == "child_org_agent_cached_tokens" {
+		orgStatistics.TotalChildOrgAgentCachedTokens += int64(increment)
+		orgStatistics.MonthlyChildOrgAgentCachedTokens += int64(increment)
+		orgStatistics.DailyChildOrgAgentCachedTokens += int64(increment)
 	} else {
 		//log.Printf("\n\n[ERROR] Unknown data type in stats increment for org %s: %s. Appending to custom list.\n\n", orgStatistics.OrgId, dataType)
 		appendCustom = true

--- a/structs.go
+++ b/structs.go
@@ -415,6 +415,13 @@ type DailyStatistics struct {
 	AgentInputTokens           int64 `json:"agent_input_tokens" datastore:"agent_input_tokens"`
 	AgentOutputTokens          int64 `json:"agent_output_tokens" datastore:"agent_output_tokens"`
 	AgentCachedTokens          int64 `json:"agent_cached_tokens" datastore:"agent_cached_tokens"`
+	ChildOrgAgentExecutions           int64 `json:"child_org_agent_executions" datastore:"child_org_agent_executions"`
+	ChildOrgAgentExecutionsSuccessful int64 `json:"child_org_agent_executions_successful" datastore:"child_org_agent_executions_successful"`
+	ChildOrgAgentExecutionsFailed     int64 `json:"child_org_agent_executions_failed" datastore:"child_org_agent_executions_failed"`
+	ChildOrgAgentTokens               int64 `json:"child_org_agent_tokens" datastore:"child_org_agent_tokens"`
+	ChildOrgAgentInputTokens          int64 `json:"child_org_agent_input_tokens" datastore:"child_org_agent_input_tokens"`
+	ChildOrgAgentOutputTokens         int64 `json:"child_org_agent_output_tokens" datastore:"child_org_agent_output_tokens"`
+	ChildOrgAgentCachedTokens         int64 `json:"child_org_agent_cached_tokens" datastore:"child_org_agent_cached_tokens"`
 
 	ApiUsage int64      `json:"api_usage" datastore:"api_usage"`
 	AppUsage []AppUsage `json:"app_usage" datastore:"app_usage"`
@@ -452,6 +459,13 @@ type ExecutionInfo struct {
 	TotalAgentInputTokens           int64 `json:"total_agent_input_tokens" datastore:"total_agent_input_tokens"`
 	TotalAgentOutputTokens          int64 `json:"total_agent_output_tokens" datastore:"total_agent_output_tokens"`
 	TotalAgentCachedTokens          int64 `json:"total_agent_cached_tokens" datastore:"total_agent_cached_tokens"`
+	TotalChildOrgAgentExecutions           int64 `json:"total_child_org_agent_executions" datastore:"total_child_org_agent_executions"`
+	TotalChildOrgAgentExecutionsSuccessful int64 `json:"total_child_org_agent_executions_successful" datastore:"total_child_org_agent_executions_successful"`
+	TotalChildOrgAgentExecutionsFailed     int64 `json:"total_child_org_agent_executions_failed" datastore:"total_child_org_agent_executions_failed"`
+	TotalChildOrgAgentTokens               int64 `json:"total_child_org_agent_tokens" datastore:"total_child_org_agent_tokens"`
+	TotalChildOrgAgentInputTokens          int64 `json:"total_child_org_agent_input_tokens" datastore:"total_child_org_agent_input_tokens"`
+	TotalChildOrgAgentOutputTokens         int64 `json:"total_child_org_agent_output_tokens" datastore:"total_child_org_agent_output_tokens"`
+	TotalChildOrgAgentCachedTokens         int64 `json:"total_child_org_agent_cached_tokens" datastore:"total_child_org_agent_cached_tokens"`
 	TotalChildWorkflowExecutions    int64 `json:"total_child_workflow_executions" datastore:"total_child_workflow_executions"`
 
 	MonthlyApiUsage                   int64 `json:"monthly_api_usage,omitempty" datastore:"monthly_api_usage"`
@@ -474,6 +488,13 @@ type ExecutionInfo struct {
 	MonthlyAgentInputTokens           int64 `json:"monthly_agent_input_tokens,omitempty" datastore:"monthly_agent_input_tokens"`
 	MonthlyAgentOutputTokens          int64 `json:"monthly_agent_output_tokens,omitempty" datastore:"monthly_agent_output_tokens"`
 	MonthlyAgentCachedTokens          int64 `json:"monthly_agent_cached_tokens,omitempty" datastore:"monthly_agent_cached_tokens"`
+	MonthlyChildOrgAgentExecutions           int64 `json:"monthly_child_org_agent_executions,omitempty" datastore:"monthly_child_org_agent_executions"`
+	MonthlyChildOrgAgentExecutionsSuccessful int64 `json:"monthly_child_org_agent_executions_successful,omitempty" datastore:"monthly_child_org_agent_executions_successful"`
+	MonthlyChildOrgAgentExecutionsFailed     int64 `json:"monthly_child_org_agent_executions_failed,omitempty" datastore:"monthly_child_org_agent_executions_failed"`
+	MonthlyChildOrgAgentTokens               int64 `json:"monthly_child_org_agent_tokens,omitempty" datastore:"monthly_child_org_agent_tokens"`
+	MonthlyChildOrgAgentInputTokens          int64 `json:"monthly_child_org_agent_input_tokens,omitempty" datastore:"monthly_child_org_agent_input_tokens"`
+	MonthlyChildOrgAgentOutputTokens         int64 `json:"monthly_child_org_agent_output_tokens,omitempty" datastore:"monthly_child_org_agent_output_tokens"`
+	MonthlyChildOrgAgentCachedTokens         int64 `json:"monthly_child_org_agent_cached_tokens,omitempty" datastore:"monthly_child_org_agent_cached_tokens"`
 
 	WeeklyAppExecutions              int64 `json:"weekly_app_executions,omitempty" datastore:"weekly_app_executions"`
 	WeeklyChildAppExecutions         int64 `json:"weekly_child_app_executions,omitempty" datastore:"weekly_child_app_executions"`
@@ -507,6 +528,13 @@ type ExecutionInfo struct {
 	DailyAgentInputTokens           int64 `json:"daily_agent_input_tokens" datastore:"daily_agent_input_tokens"`
 	DailyAgentOutputTokens          int64 `json:"daily_agent_output_tokens" datastore:"daily_agent_output_tokens"`
 	DailyAgentCachedTokens          int64 `json:"daily_agent_cached_tokens" datastore:"daily_agent_cached_tokens"`
+	DailyChildOrgAgentExecutions           int64 `json:"daily_child_org_agent_executions" datastore:"daily_child_org_agent_executions"`
+	DailyChildOrgAgentExecutionsSuccessful int64 `json:"daily_child_org_agent_executions_successful" datastore:"daily_child_org_agent_executions_successful"`
+	DailyChildOrgAgentExecutionsFailed     int64 `json:"daily_child_org_agent_executions_failed" datastore:"daily_child_org_agent_executions_failed"`
+	DailyChildOrgAgentTokens               int64 `json:"daily_child_org_agent_tokens" datastore:"daily_child_org_agent_tokens"`
+	DailyChildOrgAgentInputTokens          int64 `json:"daily_child_org_agent_input_tokens" datastore:"daily_child_org_agent_input_tokens"`
+	DailyChildOrgAgentOutputTokens         int64 `json:"daily_child_org_agent_output_tokens" datastore:"daily_child_org_agent_output_tokens"`
+	DailyChildOrgAgentCachedTokens         int64 `json:"daily_child_org_agent_cached_tokens" datastore:"daily_child_org_agent_cached_tokens"`
 
 	HourlyAppExecutions              int64 `json:"hourly_app_executions,omitempty" datastore:"hourly_app_executions"`
 	HourlyChildAppExecutions         int64 `json:"hourly_child_app_executions,omitempty" datastore:"hourly_child_app_executions"`


### PR DESCRIPTION
**Changes:**
- Added all Total, Monthly, and Daily `child_org_agent_...` metric fields to `ExecutionInfo`. This Fixes an issue where Datastore threw `no such struct field` errors during Org/User loading (specifically for fields like `daily_child_org_agent_input_tokens`). 

- And also updated the `ai model` to `gpt-5.6-luna` due to slightly better performance and smarter and much cheaper than the mini